### PR TITLE
Add cvv cardTypeLength validator to allow card types to require a cer…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Returns true if card cvv has a valid min length
 ##### `cruPayments.creditCard.cvv.validate.maxLength(cvv)`
 Returns true if card cvv has a valid max length
 
-##### `cruPayments.creditCard.cvv.validate.all(cvv)`
+##### `cruPayments.creditCard.cvv.validate.cardTypeLength(cvv, cardType)`
+Returns true if card cvv length matches the allowed lengths for the given card type
+
+##### `cruPayments.creditCard.cvv.validate.all(cvv, cardNumber)`
 Returns true if all of the above cvv validators return true
 
 #### Card Expiry Date

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cru-payments",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Library for validating and encrypting credit card and bank account info",
   "main": "dist/cru-payments.js",
   "scripts": {

--- a/src/credit-card/card-number/utils/card-types.ts
+++ b/src/credit-card/card-number/utils/card-types.ts
@@ -1,35 +1,35 @@
 import {cleanInput} from '../../../utils/parsing';
 
-const cardTypes = [
+export const cardTypeConsts = [
   {
-    name: 'VISA',
-    displayName: 'Visa',
+    name: 'Visa',
     lengths: [13, 16],
-    prefixExpression: '4'
+    prefixExpression: '4',
+    cvvLengths: [3, 4]
   },
   {
-    name: 'MASTERCARD',
-    displayName: 'MasterCard',
+    name: 'MasterCard',
     lengths: [16],
-    prefixExpression: '5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[01]|2720'
+    prefixExpression: '5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[01]|2720',
+    cvvLengths: [3, 4]
   },
   {
-    name: 'AMERICAN_EXPRESS',
-    displayName: 'American Express',
+    name: 'American Express',
     lengths: [15],
-    prefixExpression: '3[4,7]'
+    prefixExpression: '3[4,7]',
+    cvvLengths: [4]
   },
   {
-    name: 'DISCOVER',
-    displayName: 'Discover',
+    name: 'Discover',
     lengths: [16],
-    prefixExpression: '65|64[4-9]|622|6011|35[2-8]'
+    prefixExpression: '65|64[4-9]|622|6011|35[2-8]',
+    cvvLengths: [3, 4]
   },
   {
-    name: 'DINERS_CLUB',
-    displayName: 'Diners Club',
+    name: 'Diners Club',
     lengths: [14],
-    prefixExpression: '36|30[0-5]'
+    prefixExpression: '36|30[0-5]',
+    cvvLengths: [3, 4]
   }
 ];
 
@@ -43,7 +43,7 @@ export function validateTypeLength(cardNumber: string){
 
 export function getCardTypeName(cardNumber: string){
   const cardType = getCardType(cardNumber);
-  return cardType ? cardType.displayName : '';
+  return cardType ? cardType.name : '';
 }
 
 export function expectedLength(cardNumber: string){
@@ -52,7 +52,7 @@ export function expectedLength(cardNumber: string){
 }
 
 function getCardType(cardNumber: string) {
-  for(const cardType of cardTypes) {
+  for(const cardType of cardTypeConsts) {
     const cardExpression = new RegExp('^(' + cardType.prefixExpression + ')');
     if(cardExpression.test(cardNumber)){
       return cardType;

--- a/src/credit-card/credit-card.spec.ts
+++ b/src/credit-card/credit-card.spec.ts
@@ -38,6 +38,7 @@ describe('credit card', () => {
         validate: {
           minLength: jasmine.any(Function),
           maxLength: jasmine.any(Function),
+          cardTypeLength: jasmine.any(Function),
           all: jasmine.any(Function)
         }
       });

--- a/src/credit-card/credit-card.ts
+++ b/src/credit-card/credit-card.ts
@@ -2,7 +2,7 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/throw';
 import {cleanInput} from '../utils/parsing';
 import * as cardNumberModule from './card-number/card-number';
-import {validateMinLength as cvvValidateMinLength, validateMaxLength as cvvValidateMaxLength, validateAll as cvvValidateAll} from './cvv/cvv';
+import {validateMinLength as cvvValidateMinLength, validateMaxLength as cvvValidateMaxLength, validateCardTypeLength as ccvValidateCardTypeLength, validateAll as cvvValidateAll} from './cvv/cvv';
 import {validateMonth, validateYear} from './expiry-date/expiry-date';
 import {encrypt as creditCardEncrypt} from '../payment-providers/tsys/tsys';
 
@@ -28,6 +28,7 @@ export const cvv = {
   validate: {
     minLength: cvvValidateMinLength,
     maxLength: cvvValidateMaxLength,
+    cardTypeLength: ccvValidateCardTypeLength,
     all: cvvValidateAll
   }
 };
@@ -42,7 +43,7 @@ export const expiryDate = {
 
 export function validate(cardNumber: string|number, cvvInput: string|number, month: string|number, year: string|number){
   return card.validate.all(cardNumber) &&
-    cvv.validate.all(cvvInput) &&
+    cvv.validate.all(cvvInput, card.info.type(cardNumber)) &&
     expiryDate.validate.all(month, year);
 }
 

--- a/src/credit-card/cvv/cvv.spec.ts
+++ b/src/credit-card/cvv/cvv.spec.ts
@@ -45,6 +45,39 @@ describe('cvv', () => {
       expect(cvv.validateMaxLength(1234567)).toEqual(false);
     });
   });
+  describe('validateCardTypeLength', () => {
+    it('should clean input', () => {
+      spyOn(parsing, 'cleanInput').and.callThrough();
+      cvv.validateCardTypeLength(123, 'Visa');
+      expect(parsing.cleanInput).toHaveBeenCalledWith(123);
+    });
+    it('should return true if cardType is not set', () => {
+      expect(cvv.validateCardTypeLength(123)).toEqual(true);
+    });
+    it('should return true if cvv length is correct for the given card type', () => {
+      expect(cvv.validateCardTypeLength(123, 'Visa')).toEqual(true);
+      expect(cvv.validateCardTypeLength(1234, 'Visa')).toEqual(true);
+      expect(cvv.validateCardTypeLength(123, 'MasterCard')).toEqual(true);
+      expect(cvv.validateCardTypeLength(1234, 'MasterCard')).toEqual(true);
+      expect(cvv.validateCardTypeLength(1234, 'American Express')).toEqual(true);
+      expect(cvv.validateCardTypeLength(123, 'Discover')).toEqual(true);
+      expect(cvv.validateCardTypeLength(1234, 'Discover')).toEqual(true);
+      expect(cvv.validateCardTypeLength(123, 'Diners Club')).toEqual(true);
+      expect(cvv.validateCardTypeLength(1234, 'Diners Club')).toEqual(true);
+    });
+    it('should return false if cvv length is incorrect for the given card type', () => {
+      expect(cvv.validateCardTypeLength(12, 'Visa')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12345, 'Visa')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12, 'MasterCard')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12345, 'MasterCard')).toEqual(false);
+      expect(cvv.validateCardTypeLength(123, 'American Express')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12345, 'American Express')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12, 'Discover')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12345, 'Discover')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12, 'Diners Club')).toEqual(false);
+      expect(cvv.validateCardTypeLength(12345, 'Diners Club')).toEqual(false);
+    });
+  });
   describe('validateAll', () => {
     it('should return true if cvv is valid', () => {
       expect(cvv.validateAll(123)).toEqual(true);

--- a/src/credit-card/cvv/cvv.ts
+++ b/src/credit-card/cvv/cvv.ts
@@ -1,4 +1,5 @@
 import {cleanInput} from '../../utils/parsing';
+import {cardTypeConsts} from '../card-number/utils/card-types';
 
 export function validateMinLength(input: string|number){
   const cvv = cleanInput(input);
@@ -10,9 +11,19 @@ export function validateMaxLength(input: string|number){
   return cvv.length <= 4;
 }
 
-export function validateAll(input: string|number){
+export function validateCardTypeLength(input: string|number, cardType?: string){
+  if(!cardType){
+    return true;
+  }
+  const cvv = cleanInput(input);
+  const validLengths = cardTypeConsts.filter(cardTypeConst => cardTypeConst.name === cardType)[0].cvvLengths;
+  return validLengths.indexOf(cvv.length) !== -1;
+}
+
+export function validateAll(input: string|number, cardType?: string){
   const cvv = cleanInput(input);
   return !!cvv &&
     validateMinLength(cvv) &&
-    validateMaxLength(cvv);
+    validateMaxLength(cvv) &&
+    validateCardTypeLength(cvv, cardType);
 }


### PR DESCRIPTION
…ain CVV length

- Set American Express to only allow CVV lengths of 4
- Remove unused cardType name field and rename displayName to name

Brought up by https://jira.cru.org/browse/EP-1756