### PR TITLE
Remove code that deletes TSEP divs and reinitializes the TSEP library…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Note: If you only need to accept one type of payment, use one of the specific bu
 #### Use with a module loader
 1. `import cruPayments from 'cru-payments/dist/cru-payments';`
 
+#### Use with Internet Explorer
+IE 10 requires the [MutationObserver polyfill](https://github.com/megawac/MutationObserver.js) to be included before cru-payments (Required for credit card payments only)
+Credit card payments do not work in IE 9 or below
+Bank account payments do not work in IE 8 or below
+
 ### Build and use locally
 1. `yarn` or `npm install`
 2. `yarn run build` or `npm run build`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cru-payments",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Library for validating and encrypting credit card and bank account info",
   "main": "dist/cru-payments.js",
   "scripts": {

--- a/src/payment-providers/ccp/ccp.spec.ts
+++ b/src/payment-providers/ccp/ccp.spec.ts
@@ -50,7 +50,7 @@ describe('ccp', () => {
           });
     });
     it('should use the key returned by the api', (done) => {
-      (<any> window).fetch.and.callFake(() => Promise.resolve({ ok: true, text: () => '<key from api>' }));
+      (<any> window).fetch.and.callFake(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<key from api>') }));
       ccp.init('staging', '<backup key>');
       ccp._ccpKeyObservable
         .subscribe(key => {
@@ -60,7 +60,7 @@ describe('ccp', () => {
         }, () => done.fail('should not have thrown an error'));
     });
     it('should use the key returned by the production api', (done) => {
-      (<any> window).fetch.and.callFake(() => Promise.resolve({ ok: true, text: () => '<key from api>' }));
+      (<any> window).fetch.and.callFake(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<key from api>') }));
       ccp.init('production', '<backup key>');
       ccp._ccpKeyObservable
         .subscribe(key => {

--- a/src/payment-providers/ccp/ccp.ts
+++ b/src/payment-providers/ccp/ccp.ts
@@ -23,7 +23,7 @@ export function init(env: string, backupKey?: string){
   ccpKeyObservable = Observable.from((<any> window).fetch(env === 'production' ? prodKeyUri : stagingKeyUri))
     .mergeMap((response: Response) => {
       if (response.ok) {
-        return Observable.of(response.text());
+        return Observable.from(response.text());
       }else{
         return Observable.throw(response.statusText);
       }


### PR DESCRIPTION
… on each new encryption

- Rely on the first initialization of TSEP only. New keys are still retrieved on each encryption but the library code isn’t reinitialized each time
- Only consider TSYS responses with a status property of PASS to be successful tokenizations
- Fix bank account api key response handling to expect a promise

This simplifies the code, fixes IE script errors, and should prepare IE to perform multiple tokenizations once the TSYS server cache headers are set correctly. From my testing it seems that only IE and Edge are caching the keys and other browsers are behaving fine.

@canac you can review too