### PR TITLE
Remove MutationObserver polyfill instructions from readme as it is no…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Note: If you only need to accept one type of payment, use one of the specific bu
 1. `import cruPayments from 'cru-payments/dist/cru-payments';`
 
 #### Use with Internet Explorer
-IE 10 requires the [MutationObserver polyfill](https://github.com/megawac/MutationObserver.js) to be included before cru-payments (Required for credit card payments only)
 Credit card payments do not work in IE 9 or below
 Bank account payments do not work in IE 8 or below
 


### PR DESCRIPTION
… longer needed

I forgot to remove this.