### PR TITLE
Allow CVV to be optional

### DIFF
--- a/src/credit-card/credit-card.spec.ts
+++ b/src/credit-card/credit-card.spec.ts
@@ -108,6 +108,15 @@ describe('credit card', () => {
           done.fail('Observable should not have thrown an error');
         });
     });
+    it('should allow a null cvv which indicates that the cvv is optional', (done) => {
+      creditCard.encrypt('4111111111111111', null, 4, 2015)
+        .subscribe(response => {
+          expect(response).toEqual('<tsys card token>');
+          done();
+        }, () => {
+          done.fail('Observable should not have thrown an error');
+        });
+    });
     it('should return an errored Observable if encryption was unsuccessful', (done) => {
       (<jasmine.Spy> tsys.encrypt).and.returnValue(Observable.throw('some error'));
       creditCard.encrypt('4111111111111111', '123', 4, 2015)

--- a/src/credit-card/credit-card.ts
+++ b/src/credit-card/credit-card.ts
@@ -53,5 +53,6 @@ export function encrypt(cardNumber: string|number, cvv: string|number, month: st
   if(!validate(cardNumber, cvv, month, year)){
     return Observable.throw('Credit card details invalid');
   }
-  return creditCardEncrypt(cleanInput(cardNumber), cleanInput(cvv), Number(cleanInput(month)), Number(cleanInput(year)));
+  // allow CVV to be optional if it is null
+  return creditCardEncrypt(cleanInput(cardNumber), cvv === null ? null : cleanInput(cvv), Number(cleanInput(month)), Number(cleanInput(year)));
 }

--- a/src/credit-card/cvv/cvv.spec.ts
+++ b/src/credit-card/cvv/cvv.spec.ts
@@ -90,9 +90,8 @@ describe('cvv', () => {
       expect(cvv.validateCardTypeLength(1234, 'American Express')).toEqual(true);
       expect(cvv.validateCardTypeLength(123, 'Visa')).toEqual(true);
     });
-    it('should return false if if cvv is invalid', () => {
+    it('should return false if cvv is invalid', () => {
       expect(cvv.validateAll(undefined)).toEqual(false);
-      expect(cvv.validateAll(null)).toEqual(false);
       expect(cvv.validateAll('')).toEqual(false);
       expect(cvv.validateAll(1)).toEqual(false);
       expect(cvv.validateAll(12)).toEqual(false);
@@ -129,6 +128,9 @@ describe('cvv', () => {
     });
     it('should return an empty array for a valid cvv', () => {
       expect(cvv.errors('123', 'MasterCard')).toEqual([]);
+    });
+    it('should return true if cvv is null which indicates that the cvv is optional', () => {
+      expect(cvv.validateAll(null)).toEqual(true);
     });
   });
 });

--- a/src/credit-card/cvv/cvv.ts
+++ b/src/credit-card/cvv/cvv.ts
@@ -21,6 +21,9 @@ export function validateCardTypeLength(input: string|number, cardType?: string){
 }
 
 export function validateAll(input: string|number, cardType?: string){
+  if(input === null){ // allow CVV to be optional if it is null
+    return true;
+  }
   const cvv = cleanInput(input);
   return !!cvv &&
     validateMinLength(cvv) &&

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -1,8 +1,8 @@
-export function stripNonDigits(number: string){
+export function stripNonDigits(number: string): string{
   return number.replace(/\D/g, '');
 }
 
-export function cleanInput(number: string|number){
+export function cleanInput(number: string|number): string{
   let numberString: string = String(number);
   numberString = stripNonDigits(numberString);
   return numberString;


### PR DESCRIPTION
- Clients must pass `null` in the CVV field when calling `cruPayments.creditCard.validate` or `cruPayments.creditCard.encrypt` for it to be optional

[Bill needs for the CVV to be optional in branded checkout.](https://jira.cru.org/browse/EP-1807?focusedCommentId=50967)

Let me know if you guys have any suggestions for better ways to implement this. In Angular, it seems that an empty or invalid input will be set to `undefined` and if it is passed straight to cru-payments, cru-payments will still mark it as invalid. There might be some risk in doing this if some of our other jQuery apps want to require a CVV but fill this value with null if an input is empty or invalid. I thought about making the client pass `false` or some specific string like `'cvv not required'` in the cvv field or making a separate `encryptWithoutCvv` function but idk that those are better solutions. I'm happy to make any changes you guys come up with.