### PR TITLE
Update CCP staging url to ccpstaging.cru.org

### DIFF
--- a/src/payment-providers/ccp/ccp.spec.ts
+++ b/src/payment-providers/ccp/ccp.spec.ts
@@ -6,7 +6,7 @@ describe('ccp', () => {
   describe('init', () => {
     it('should use the backup key provided if there\'s a network error while fetching the key', (done) => {
       mockOnce(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        'https://ccpstaging.cru.org/api/v1/rest/client-encryption-keys/current',
         { throws: new TypeError('Failed to fetch') }
       );
       ccp.init('staging', '<backup key>');
@@ -18,7 +18,7 @@ describe('ccp', () => {
     });
     it('should use the backup key provided if the api returns a non-ok status code while fetching the key', (done) => {
       mockOnce(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        'https://ccpstaging.cru.org/api/v1/rest/client-encryption-keys/current',
         500
       );
       ccp.init('staging', '<backup key>');
@@ -30,7 +30,7 @@ describe('ccp', () => {
     });
     it('should throw an error if no backup key was provided and there was a network error fetching the key from the api', (done) => {
       mockOnce(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        'https://ccpstaging.cru.org/api/v1/rest/client-encryption-keys/current',
         { throws: new TypeError('Failed to fetch') }
       );
       ccp.init('staging');
@@ -43,7 +43,7 @@ describe('ccp', () => {
     });
     it('should throw an error if no backup key was provided and there was a server error fetching the key from the api', (done) => {
       mockOnce(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        'https://ccpstaging.cru.org/api/v1/rest/client-encryption-keys/current',
         500
       );
       ccp.init('staging');
@@ -56,7 +56,7 @@ describe('ccp', () => {
     });
     it('should use the key returned by the api', (done) => {
       mockOnce(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        'https://ccpstaging.cru.org/api/v1/rest/client-encryption-keys/current',
         '<key from api>'
       );
       ccp.init('staging', '<backup key>');
@@ -83,7 +83,7 @@ describe('ccp', () => {
     beforeEach(() => {
       // Setup ccp to use provided backup key
       mockOnce(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        'https://ccpstaging.cru.org/api/v1/rest/client-encryption-keys/current',
         500
       );
       this.validKey = `-----BEGIN PUBLIC KEY-----

--- a/src/payment-providers/ccp/ccp.ts
+++ b/src/payment-providers/ccp/ccp.ts
@@ -15,7 +15,7 @@ import 'whatwg-fetch';
 import {JSEncrypt} from 'jsencrypt';
 
 const prodKeyUri = 'https://ccp.ccci.org/api/v1/rest/client-encryption-keys/current';
-const stagingKeyUri = 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current';
+const stagingKeyUri = 'https://ccpstaging.cru.org/api/v1/rest/client-encryption-keys/current';
 
 let ccpKeyObservable: Observable<string>;
 


### PR DESCRIPTION
This DNS name points to a CloudFront distribution in front of ccpstaging.ccci.org. The CloudFront distribution will make the public key calls less likely to fail.

Every so often, we've seen the give site receive encrypted bank accounts that were encrypted with a stale key, which means that the call to fetch the public key had failed and the fallback key was used,
and the fallback key was out of date. The public key call failure is not logged in detail, and it's likely the browser wouldn't tell us much anyway, so it's hard to know what the root cause has been. Regardless, it's much more likely that a CloudFront cache will reduce failures, because in the rare times that CCP is down the cache will probably be available.

The production url will be similarly be updated in a future commit.