### PR TITLE
Switched the GHA NPM publish trigger from published to released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [master]
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
`published` was not triggered when a new release was published.