### PR TITLE
Have to bump the patch number to update the ReadMe on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/CruPCI/cru-payments/branch/master/graph/badge.svg)](https://codecov.io/gh/CruPCI/cru-payments)
 
 ## Breaking changes in v1.2.3
-#### This package is the new version of `cru-payments`.
+#### `@cruglobal/cru-payments` is the new version of `cru-payments`.
 
 #### You will now need to import `@cruglobal/cru-payments` as a wildcard.
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruglobal/cru-payments",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Library for validating and encrypting credit card and bank account info",
   "main": "dist/cru-payments.js",
   "scripts": {


### PR DESCRIPTION
I published version 1.2.3 before I edited the ReadMe with the updated. So I need to bump the version number to update NPM package.