### PR TITLE
[no-Jira] Set up npm Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
-      - run: yarn install --immutable --immutable-cache
+      - name: 📦 Install Dependencies
+        run: yarn install --immutable --immutable-cache
       - name: 👤 Configure git
         run: |
           git config --global user.name 'GitHub Action'
           git config --global user.email 'github-action@users.noreply.github.com'
       - name: 🎁 Publish package to NPM and bump version
-        run: yarn publish --access public --new-version ${{ github.event.release.tag_name }}
+        run: |
+          # Use npm because yarn does not yet support trusted publishing
+          # Use the latest version of npm to ensure we have a version >= 11.5.1 that supports trusted publishing
+          npm install --global npm@latest
+          npm version ${{ github.event.release.tag_name }} --no-git-tag-version
+          npx publish --access public
 
   slackNotification:
     name: 📨 Slack Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           # Use the latest version of npm to ensure we have a version >= 11.5.1 that supports trusted publishing
           npm install --global npm@latest
           npm version ${{ github.event.release.tag_name }} --no-git-tag-version
-          npx publish --access public
+          npm publish --access public
 
   slackNotification:
     name: 📨 Slack Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
-          registry-url: "https://registry.npmjs.org"
-          scope: "@cruglobal"
       - run: yarn install --immutable --immutable-cache
       - name: 👤 Configure git
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
     if: github.event_name == 'release'
     name: 🚀 Deploy to NPM
     needs: [lint, test, build]
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       # Setup .npmrc file to publish to npm
@@ -89,8 +92,6 @@ jobs:
           git config --global user.email 'github-action@users.noreply.github.com'
       - name: 🎁 Publish package to NPM and bump version
         run: yarn publish --access public --new-version ${{ github.event.release.tag_name }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   slackNotification:
     name: 📨 Slack Notification

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@cruglobal:registry=https://registry.npmjs.org

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@cruglobal:registry=https://registry.npmjs.org

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruglobal/cru-payments",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "Library for validating and encrypting credit card and bank account info",
   "main": "dist/cru-payments.js",
   "scripts": {


### PR DESCRIPTION
Set up npm Trusted Publishing. After this change, we can delete the `NODE_AUTH_TOKEN` secret.

I had to create an `.npmrc` file manually because `actions/setup-node` sets up auth from `env.NODE_AUTH_TOKEN` when you specify a registry url ([docs](https://github.com/actions/setup-node/blob/releases/v4/README.md?plain=1#L66-L69)). We don't want an explicit auth token to use trusted publishing.

I used these changes to successfully publish v1.3.1-beta.1. After we merge this, we can release v1.3.1.