### PR TITLE
[CRITICAL] Stop exposing plaintext CVV in TSYS tokenization responses and errors

### DIFF
--- a/src/payment-providers/tsys/tsys.spec.ts
+++ b/src/payment-providers/tsys/tsys.spec.ts
@@ -225,9 +225,29 @@ describe('tsys', () => {
               })
             },
             jasmine.any(Function),
-            'performing tokenization'
+            'performing tokenization',
+            jasmine.any(Function)
           );
-          expect(data).toEqual(tokenObj);
+          expect(data).toEqual({
+            cardType: 'X',
+            expirationDate: '10/2017',
+            maskedCardNumber: '1000',
+            message: 'Success',
+            responseCode: 'A0000',
+            status: 'PASS',
+            transactionID: '6417599',
+            tsepToken: 'aNWEmSu7RRF1000'
+          });
+          done();
+        }, () => done.fail('should not have thrown an error'));
+    });
+
+    it('should not include cvv2 in a successful tokenization response', (done) => {
+      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of({ status: 'PASS', cvv2: '123', tsepToken: 'aNWEmSu7RRF1000' }));
+      tsys.encrypt('1234567890123', '123', 12, 2015)
+        .subscribe(data => {
+          expect(data.cvv2).toBeUndefined();
+          expect(data).toEqual({ status: 'PASS', tsepToken: 'aNWEmSu7RRF1000' });
           done();
         }, () => done.fail('should not have thrown an error'));
     });
@@ -247,7 +267,8 @@ describe('tsys', () => {
               })
             },
             jasmine.any(Function),
-            'performing tokenization'
+            'performing tokenization',
+            jasmine.any(Function)
           );
           expect(data).toEqual({ status: 'PASS' });
           done();
@@ -278,6 +299,31 @@ describe('tsys', () => {
             done();
           });
     });
+
+    it('should not include cvv2 in a tokenization error', (done) => {
+      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of({ status: 'FAILURE', cvv2: '123', message: 'Tokenization failed' }));
+      tsys.encrypt('1234567890123', '123', 12, 2015)
+        .subscribe(() => done.fail('should have thrown an error'),
+          (error: TsysError) => {
+            expect(error.data.cvv2).toBeUndefined();
+            expect(error).toEqual({ message: 'Tokenization error', data: { status: 'FAILURE', message: 'Tokenization failed' } });
+            done();
+          });
+    });
+
+    it('should redact cvv2 from the body of a tokenization server error', (done) => {
+      fetchMock.once(
+        '<url>/generateTsepToken',
+        new Response('{"status":"FAILURE","cvv2":"123","message":"Bad Request"}', { status: 400, statusText: 'Bad Request' })
+      );
+      tsys.encrypt('1234567890123', '123', 12, 2015)
+        .subscribe(() => done.fail('should have thrown an error'),
+          (error: TsysError) => {
+            expect(error.data.body).toEqual('{"status":"FAILURE","cvv2":"[REDACTED]","message":"Bad Request"}');
+            expect(error.data.body).not.toContain('"cvv2":"123"');
+            done();
+          });
+    });
   });
 
   describe('perform live test', () => {
@@ -294,12 +340,12 @@ describe('tsys', () => {
           tsys.init('staging', tsysData.deviceId, tsysData.manifest);
           tsys.encrypt('4111111111111111', '123', 12, new Date().getFullYear() + 1)
             .subscribe(response => {
+                expect(response.cvv2).toBeUndefined();
                 expect(response).toEqual({
                   responseCode: 'A0000',
                   status: 'PASS',
                   message: 'Success',
                   expirationDate: '12/2016',
-                  cvv2: '123',
                   tsepToken: jasmine.stringMatching(/^[A-Za-z0-9]{16}$/),
                   maskedCardNumber: '1111',
                   cardType: 'V',

--- a/src/payment-providers/tsys/tsys.ts
+++ b/src/payment-providers/tsys/tsys.ts
@@ -39,7 +39,7 @@ export function init(_env: string, _deviceId: string, _manifest: string){
   manifest = _manifest;
 }
 
-function makeRequest(url: RequestInfo, init: RequestInit, bodyFn: Function, action: string){
+function makeRequest(url: RequestInfo, init: RequestInit, bodyFn: Function, action: string, errorBodySanitizer?: Function){
   return Observable.from((<any> window).fetch(url, init))
     .catch((error: Response) => Observable.throw({ message: `Network error while ${action}`, data: error }))
     .mergeMap((response: Response) => {
@@ -47,8 +47,24 @@ function makeRequest(url: RequestInfo, init: RequestInit, bodyFn: Function, acti
         return Observable.from(bodyFn(response));
       }
       return Observable.from(response.text())
-        .mergeMap(body => Observable.throw({ message: `Server error while ${action}`, data: { status: response.status, statusText: response.statusText, body: body } }));
+        .mergeMap((body: string) => Observable.throw({ message: `Server error while ${action}`, data: { status: response.status, statusText: response.statusText, body: errorBodySanitizer ? errorBodySanitizer(body) : body } }));
     });
+}
+
+// PCI-DSS forbids storing CVV2. Strip it from parsed tokenization responses so it can't leak into consumer code or error trackers.
+function stripCvv2(response: any){
+  const sanitized: any = {};
+  for(const key in response){
+    if(key !== 'cvv2'){
+      sanitized[key] = response[key];
+    }
+  }
+  return sanitized;
+}
+
+// Redact CVV2 values echoed back in raw error body text from the tokenization endpoint
+function redactCvv2(body: string){
+  return body.replace(/"cvv2"\s*:\s*"[^"]*"/g, '"cvv2":"[REDACTED]"');
 }
 
 function fetchTsysData(){
@@ -138,14 +154,16 @@ export function encrypt(cardNumber: string, cvv: string, month: number, year: nu
           })
         },
         (request: Request) => request.json(),
-        'performing tokenization'
+        'performing tokenization',
+        redactCvv2
       );
     })
     .mergeMap((response: any) => {
+      const sanitizedResponse = stripCvv2(response);
       if(response.status === 'PASS'){
-        return Observable.of(response);
+        return Observable.of(sanitizedResponse);
       }
-      return Observable.throw({ message: 'Tokenization error', data: response });
+      return Observable.throw({ message: 'Tokenization error', data: sanitizedResponse });
     });
 }
 


### PR DESCRIPTION
## Finding

**Criticality: critical — PCI data exposure (CVV2 leakage to library consumers and error trackers).**

The TSYS `/generateTsepToken` response echoes the submitted plaintext CVV back as `cvv2` (alongside `maskedCardNumber`). In `src/payment-providers/tsys/tsys.ts`:

- **`encrypt()` success path** (previously ~line 144-147): on `status === 'PASS'` the whole response was passed through via `Observable.of(response)`, so every consumer of this library received the plaintext CVV in the tokenization result.
- **`encrypt()` failure path** (previously ~line 148): on any other status, `Observable.throw({ message: 'Tokenization error', data: response })` placed the plaintext CVV inside the rejected observable/promise. Host donation sites routinely forward rejection payloads to error trackers (Sentry, Rollbar, etc.), where the CVV would be **persisted** — PCI-DSS explicitly forbids storing CVV2 (sensitive authentication data) after authorization, even encrypted. This made inadvertent prohibited storage trivial across the many production donation sites using this library.
- **`makeRequest()` HTTP-error path** (previously ~lines 49-50): a non-OK response's raw text body was thrown as error data; for the tokenization POST that body can echo request fields including `cvv2`, with the same error-tracker exposure.

## Fix

Minimal and surgical, in `src/payment-providers/tsys/tsys.ts`:

1. **`stripCvv2()` helper**: shallow-copies the parsed tokenization response without the `cvv2` key (ES5-safe; no object rest / `Object.assign`, which the `es5` target's lib lacks). Applied in `encrypt()`'s final `mergeMap` to **both** the PASS emission and the `Tokenization error` throw data.
2. **`redactCvv2()` helper + optional `errorBodySanitizer` param on `makeRequest()`**: replaces `"cvv2":"..."` values in the raw HTTP-error body with `"cvv2":"[REDACTED]"` before throwing. The sanitizer is passed **only at the tokenization POST call site** — the jsView GET behavior is unchanged.
3. **`maskedCardNumber` is intentionally kept** — it is already masked and consumers may display it.

Specs updated (`src/payment-providers/tsys/tsys.spec.ts`): the full-passthrough assertions now expect the sanitized response, the `_makeRequest` call assertions include the new sanitizer argument, and three explicit regression tests were added:
- successful tokenization response does not contain `cvv2`
- `Tokenization error` throw data does not contain `cvv2`
- HTTP-error body has `cvv2` redacted (end-to-end through `encrypt()` with a mocked 400 response)

## Risk & compatibility

- Consumers that read `response.cvv2` from the tokenization result — unlikely, but possible — would now get `undefined`. That field SHOULD never be used or stored by anyone (PCI-DSS prohibition), so this is an intentional, desirable break.
- All other response fields (`tsepToken`, `maskedCardNumber`, `status`, `responseCode`, etc.) are unchanged. `makeRequest` gains only an optional trailing parameter; existing call sites are unaffected.
- The live test `perform live test → should successfully receive a token from TSYS` (tsys.spec.ts) asserts on the real TSYS staging response; its expected object was updated to no longer include `cvv2` (plus an explicit `response.cvv2` undefined check). **This test cannot be run locally** — it requires network access to TSYS staging and only passes in CI — so the assertion update is reasoned from the sanitization being applied uniformly in `encrypt()`'s final `mergeMap`. Please confirm it passes in CI.

## Verification

- `yarn lint` → **0 errors** (67 pre-existing warnings, unchanged in nature).
- `npx karma start --browsers ChromeHeadless --single-run` → **145 tests completed, 1 test failed**. Baseline was 142 passing + the same 1 failure; the 3 new regression tests all pass. The single failure is the known environment-only failure: `tsys → perform live test → should successfully receive a token from TSYS` fails locally with `TypeError: Failed to fetch` because it hits TSYS staging for real; only CI can pass it.

_Automated review PR generated with Claude Code — please review carefully before merging._
