### PR TITLE
[HIGH] CCP: don't cache failed key fetches; retry on next encrypt and surface backup-key fallback

### DIFF
--- a/src/payment-providers/ccp/ccp.spec.ts
+++ b/src/payment-providers/ccp/ccp.spec.ts
@@ -1,6 +1,12 @@
 import * as ccp from './ccp';
 import * as fetchMock from 'fetch-mock';
-let validKey: string = '';
+
+const stagingKeyUri = 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current';
+const validKey = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0
+FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/
+3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB
+-----END PUBLIC KEY-----`;
 
 describe('ccp', () => {
   afterEach(() => {
@@ -9,8 +15,9 @@ describe('ccp', () => {
 
   describe('init', () => {
     it('should use the backup key provided if there\'s a network error while fetching the key', (done) => {
+      spyOn(console, 'warn');
       fetchMock.once(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        stagingKeyUri,
         { throws: new TypeError('Failed to fetch') }
       );
       ccp.init('staging', '<backup key>');
@@ -21,8 +28,9 @@ describe('ccp', () => {
         }, () => done.fail('should not have thrown an error'));
     });
     it('should use the backup key provided if the api returns a non-ok status code while fetching the key', (done) => {
+      spyOn(console, 'warn');
       fetchMock.once(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        stagingKeyUri,
         500
       );
       ccp.init('staging', '<backup key>');
@@ -32,9 +40,23 @@ describe('ccp', () => {
           done();
         }, () => done.fail('should not have thrown an error'));
     });
+    it('should warn via console.warn when falling back to the backup key', (done) => {
+      spyOn(console, 'warn');
+      fetchMock.once(
+        stagingKeyUri,
+        500
+      );
+      ccp.init('staging', '<backup key>');
+      ccp._ccpKeyObservable
+        .subscribe(() => {
+          // eslint-disable-next-line no-console
+          expect(console.warn).toHaveBeenCalledWith('CCP key fetch failed; using provided backup key: Internal Server Error');
+          done();
+        }, () => done.fail('should not have thrown an error'));
+    });
     it('should throw an error if no backup key was provided and there was a network error fetching the key from the api', (done) => {
       fetchMock.once(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        stagingKeyUri,
         { throws: new TypeError('Failed to fetch') }
       );
       ccp.init('staging');
@@ -47,7 +69,7 @@ describe('ccp', () => {
     });
     it('should throw an error if no backup key was provided and there was a server error fetching the key from the api', (done) => {
       fetchMock.once(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        stagingKeyUri,
         500
       );
       ccp.init('staging');
@@ -60,7 +82,7 @@ describe('ccp', () => {
     });
     it('should use the key returned by the api', (done) => {
       fetchMock.once(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        stagingKeyUri,
         '<key from api>'
       );
       ccp.init('staging', '<backup key>');
@@ -82,19 +104,28 @@ describe('ccp', () => {
           done();
         }, () => done.fail('should not have thrown an error'));
     });
+    it('should not fetch the key until the observable is subscribed to', (done) => {
+      fetchMock.mock(
+        stagingKeyUri,
+        validKey
+      );
+      ccp.init('staging');
+      expect(fetchMock.called(stagingKeyUri)).toEqual(false);
+      ccp.encrypt('1234567890123456')
+        .subscribe(() => {
+          expect(fetchMock.called(stagingKeyUri)).toEqual(true);
+          done();
+        }, () => done.fail('should not have thrown an error'));
+    });
   });
   describe('encrypt', () => {
     beforeEach(() => {
       // Setup ccp to use provided backup key
+      spyOn(console, 'warn');
       fetchMock.once(
-        'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current',
+        stagingKeyUri,
         500
       );
-      validKey = `-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0
-FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/
-3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB
------END PUBLIC KEY-----`;
     });
     it('should throw an error if init has not been called', (done) => {
       ccp._clear();
@@ -122,6 +153,68 @@ FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/
           expect((<string> value).length).toBeGreaterThan(50);
           done();
         }, () => done.fail('should not have thrown an error'));
+    });
+  });
+  describe('key caching and retry', () => {
+    it('should retry the key fetch on the next encrypt if a previous fetch failed', (done) => {
+      fetchMock.once(
+        stagingKeyUri,
+        { throws: new TypeError('Failed to fetch') }
+      );
+      fetchMock.mock(
+        stagingKeyUri,
+        validKey
+      );
+      ccp.init('staging');
+      ccp.encrypt('1234567890123456')
+        .subscribe(() => done.fail('first encrypt should have thrown an error'),
+          () => {
+            ccp.encrypt('1234567890123456')
+              .subscribe(value => {
+                expect((<string> value).length).toBeGreaterThan(50);
+                expect(fetchMock.calls(stagingKeyUri).length).toEqual(2);
+                done();
+              }, () => done.fail('second encrypt should not have thrown an error'));
+          });
+    });
+    it('should only fetch the key once if the fetch was successful', (done) => {
+      fetchMock.mock(
+        stagingKeyUri,
+        validKey
+      );
+      ccp.init('staging');
+      ccp.encrypt('1234567890123456')
+        .subscribe(() => {
+          ccp.encrypt('1234567890123456')
+            .subscribe(value => {
+              expect((<string> value).length).toBeGreaterThan(50);
+              expect(fetchMock.calls(stagingKeyUri).length).toEqual(1);
+              done();
+            }, () => done.fail('second encrypt should not have thrown an error'));
+        }, () => done.fail('first encrypt should not have thrown an error'));
+    });
+    it('should not cache the backup key and should recover to the fetched key on a later encrypt', (done) => {
+      spyOn(console, 'warn');
+      fetchMock.once(
+        stagingKeyUri,
+        500
+      );
+      fetchMock.mock(
+        stagingKeyUri,
+        validKey
+      );
+      ccp.init('staging', validKey);
+      ccp.encrypt('1234567890123456')
+        .subscribe(() => {
+          // eslint-disable-next-line no-console
+          expect(console.warn).toHaveBeenCalledWith('CCP key fetch failed; using provided backup key: Internal Server Error');
+          ccp.encrypt('1234567890123456')
+            .subscribe(value => {
+              expect((<string> value).length).toBeGreaterThan(50);
+              expect(fetchMock.calls(stagingKeyUri).length).toEqual(2);
+              done();
+            }, () => done.fail('second encrypt should not have thrown an error'));
+        }, () => done.fail('first encrypt should not have thrown an error'));
     });
   });
 });

--- a/src/payment-providers/ccp/ccp.ts
+++ b/src/payment-providers/ccp/ccp.ts
@@ -1,7 +1,9 @@
 import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/defer';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
+import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/catch';
@@ -18,23 +20,39 @@ const prodKeyUri = 'https://ccp.ccci.org/api/v1/rest/client-encryption-keys/curr
 const stagingKeyUri = 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current';
 
 let ccpKeyObservable: Observable<string>;
+let fetchedKey: string;
 
 export function init(env: string, backupKey?: string){
-  ccpKeyObservable = Observable.from((<any> window).fetch(env === 'production' ? prodKeyUri : stagingKeyUri))
-    .mergeMap((response: Response) => {
-      if (response.ok) {
-        return Observable.from(response.text());
-      }else{
-        return Observable.throw(response.statusText);
-      }
-    })
-    .catch(error => {
-      if(backupKey){
-        return Observable.of(backupKey);
-      }else{
-        return Observable.throw('There was an error retrieving the key from CCP and no backup key was provided: ' + error);
-      }
-    });
+  fetchedKey = null;
+  // Defer the key fetch until the first subscription (first encrypt call) so a transient
+  // network failure at page load isn't cached for the life of the page.
+  ccpKeyObservable = Observable.defer(() => {
+    if(fetchedKey){
+      return Observable.of(fetchedKey);
+    }
+    return Observable.from((<any> window).fetch(env === 'production' ? prodKeyUri : stagingKeyUri))
+      .mergeMap((response: Response) => {
+        if (response.ok) {
+          return Observable.from(response.text());
+        }else{
+          return Observable.throw(response.statusText);
+        }
+      })
+      // Cache the key only on success. A failed fetch is never cached, so the next
+      // encrypt call retries the network request.
+      .do((key: string) => fetchedKey = key)
+      .catch(error => {
+        if(backupKey){
+          // The backup key is intentionally not cached so a later encrypt call can
+          // recover to the live key once the network/API is healthy again.
+          // eslint-disable-next-line no-console
+          console.warn('CCP key fetch failed; using provided backup key: ' + error);
+          return Observable.of(backupKey);
+        }else{
+          return Observable.throw('There was an error retrieving the key from CCP and no backup key was provided: ' + error);
+        }
+      });
+  });
 }
 
 export function encrypt(accountNumber: string){
@@ -59,6 +77,7 @@ export function encrypt(accountNumber: string){
 
 function clear(){
   ccpKeyObservable = null;
+  fetchedKey = null;
 }
 
 // For testing


### PR DESCRIPTION
## Finding

`src/payment-providers/ccp/ccp.ts:23` (pre-fix) — `init()` eagerly called `window.fetch` and wrapped the resulting one-shot promise in `Observable.from`. The settled result was replayed to every subscriber, so:

1. **A transient key-fetch failure at page load was cached forever** (when no `backupKey` was provided). A donor who loaded the page during a network blip, filled out the bank account form, and submitted minutes later — after the network had recovered — would have every `bankAccount.encrypt()` call fail until a full page reload. **Silently lost donations.**
2. If a `backupKey` was provided, a failed fetch silently fell back to the static backup for the whole session with zero telemetry, masking CCP outages. A rotated-out backup key would produce undecryptable ciphertexts with no signal anything was wrong.
3. The eager fetch at init produced an unhandled promise rejection if `encrypt` was never called.

## Fix

- The key fetch is now lazy (`Observable.defer`): it fires on the first `encrypt()` subscription, not at `init()`. This also removes the unhandled rejection.
- The key is cached (module-level `fetchedKey`) **only on a successful fetch**, and subsequent encrypts short-circuit to the cached key. A failed fetch is never cached — the next `encrypt()` call retries the network request.
- Falling back to the `backupKey` now emits `console.warn('CCP key fetch failed; using provided backup key: <error>')` so integrators can detect outages. The fallback behavior itself is unchanged. The backup key is intentionally **not** cached as if it were a fetched key, so a later `encrypt()` recovers to the live key once CCP is healthy again.
- Calling `init()` again still rebuilds the observable and now also resets the cached key. `_clear()` keeps working for tests.

## Risk & compatibility

- **Public API unchanged**: `init(env, backupKey?)` and `encrypt(accountNumber)` returning an `Observable` are identical in signature and success/error semantics.
- **Timing change**: the key is now fetched on the first `encrypt()` instead of at `init()`. First-encrypt latency includes the key fetch (previously it was usually pre-warmed by page load). Given encrypts happen at form submission, well after load, this is a negligible cost against no-longer-bricking the session.
- After a backup-key fallback, each subsequent `encrypt()` retries the live fetch (one extra request per encrypt while CCP is down) — encrypts are rare, user-initiated actions, so this is harmless and is what enables recovery.

## Verification

- `yarn lint` → 0 errors (68 pre-existing warnings, untouched).
- `npx karma start --browsers ChromeHeadless --single-run` → **147 passed, 1 failed** — the single failure is the known environment failure: tsys "perform live test → should successfully receive a token from TSYS" fails locally with "Failed to fetch" (it hits TSYS staging for real). Baseline was 142 passing + that same failure; this PR adds 5 ccp tests, all passing:
  - failed fetch then successful fetch → second encrypt succeeds (fetch called twice)
  - successful fetch is cached → two encrypts, fetch called once
  - backup-key fallback warns via `console.warn`
  - backup key not cached → recovery to the live key on a later encrypt
  - no fetch fires until `encrypt()` is subscribed

_Automated review PR generated with Claude Code — please review carefully before merging._
