### PR TITLE
[MEDIUM] CVV validation: don't throw TypeError on unrecognized card type strings

### DIFF
--- a/src/credit-card/cvv/cvv.spec.ts
+++ b/src/credit-card/cvv/cvv.spec.ts
@@ -78,6 +78,11 @@ describe('cvv', () => {
       expect(cvv.validateCardTypeLength(1234, 'Diners Club')).toEqual(false);
       expect(cvv.validateCardTypeLength(12345, 'Diners Club')).toEqual(false);
     });
+    it('should return true without throwing if cardType is unrecognized', () => {
+      expect(cvv.validateCardTypeLength(123, 'VISA')).toEqual(true);
+      expect(cvv.validateCardTypeLength(1234, 'Amex')).toEqual(true);
+      expect(cvv.validateCardTypeLength('123', 'Unknown')).toEqual(true);
+    });
   });
   describe('validateAll', () => {
     it('should return true if cvv is valid', () => {
@@ -128,6 +133,10 @@ describe('cvv', () => {
     });
     it('should return an empty array for a valid cvv', () => {
       expect(cvv.errors('123', 'MasterCard')).toEqual([]);
+    });
+    it('should not throw or return a card type length error for an unrecognized card type', () => {
+      expect(cvv.errors('1234', 'Amex')).toEqual([]);
+      expect(cvv.errors('123', 'VISA')).toEqual([]);
     });
     it('should return true if cvv is null which indicates that the cvv is optional', () => {
       expect(cvv.validateAll(null)).toEqual(true);

--- a/src/credit-card/cvv/cvv.ts
+++ b/src/credit-card/cvv/cvv.ts
@@ -16,8 +16,12 @@ export function validateCardTypeLength(input: string|number, cardType?: string){
     return true;
   }
   const cvv = cleanInput(input);
-  const validLengths = cardTypeConsts.filter(cardTypeConst => cardTypeConst.name === cardType)[0].cvvLengths;
-  return validLengths.indexOf(cvv.length) !== -1;
+  const matchedCardType = cardTypeConsts.filter(cardTypeConst => cardTypeConst.name === cardType)[0];
+  if(!matchedCardType){
+    // Unrecognized card type. Like a missing card type, we can't judge the CVV length, so don't block.
+    return true;
+  }
+  return matchedCardType.cvvLengths.indexOf(cvv.length) !== -1;
 }
 
 export function validateAll(input: string|number, cardType?: string){


### PR DESCRIPTION
## Finding

`src/credit-card/cvv/cvv.ts` line 19: `validateCardTypeLength` looked up the card type with `cardTypeConsts.filter(...)[0].cvvLengths`. When `cardType` is any non-empty string other than the five exact names (`'Visa'`, `'MasterCard'`, `'American Express'`, `'Discover'`, `'Diners Club'`), the filter result is empty and `[0]` is `undefined`, so this throws `TypeError: Cannot read properties of undefined (reading 'cvvLengths')`.

Both `cvv.validate.cardTypeLength` and `cvv.errors` are documented public API that accept a free-form card type string, so concrete calls like:

- `cruPayments.creditCard.cvv.validate.cardTypeLength('123', 'VISA')`
- `cruPayments.creditCard.cvv.errors('1234', 'Amex')`

crashed the host page's validation handler instead of returning a result.

## Fix

Capture the filter result first and check it before dereferencing. When the card type is unrecognized, return `true` — the same behavior as the existing blank/missing-`cardType` path (lines 15-17): without a known card type we can't judge the expected CVV length, so we don't block the user. `filter(...)[0]` is kept (rather than `Array.prototype.find`) to stay safe for the ES5/old-browser target already used by this code.

Added regression tests covering unrecognized card type strings for both `validateCardTypeLength` (returns `true`, no throw) and `errors` (no card-type-length error).

## Risk & compatibility

None expected. Behavior is unchanged for all recognized card types and for blank/missing card types; inputs that previously threw a `TypeError` now return a value consistent with the missing-card-type path.

## Verification

- `yarn lint` — 0 errors (pre-existing style warnings only)
- `npx karma start --browsers ChromeHeadless --single-run` — 144 passed (baseline 142 + 2 new tests), 1 failure: the known environment-dependent live TSYS test ("should successfully receive a token from TSYS" / "Failed to fetch"), which hits TSYS staging for real and fails identically on master.

_Automated review PR generated with Claude Code — please review carefully before merging._