### PR TITLE
[MEDIUM] Accept 2-digit expiry years (MM/YY forms are currently always declined)

### DIFF
--- a/src/credit-card/expiry-date/expiry-date.spec.ts
+++ b/src/credit-card/expiry-date/expiry-date.spec.ts
@@ -41,6 +41,14 @@ describe('expiry date', () => {
       expect(validateMonth('0', '2016')).toEqual(false);
       expect(validateMonth('12', '2016')).toEqual(true);
     });
+    it('should support 2-digit years', () => {
+      const currentTwoDigitYear = new Date().getFullYear() - 2000; // 15
+      expect(validateMonth(1, currentTwoDigitYear - 1)).toEqual(false); // '14' is in the past
+      expect(validateMonth(3, String(currentTwoDigitYear))).toEqual(false); // month in the past of '15'
+      expect(validateMonth(4, String(currentTwoDigitYear))).toEqual(true); // current month of '15'
+      expect(validateMonth('12', String(currentTwoDigitYear + 1))).toEqual(true); // '16' is in the future
+      expect(validateMonth('12', '28')).toEqual(true);
+    });
   });
   describe('validateYear', () => {
     it('should return false if the year is less than the current year', () => {
@@ -59,6 +67,20 @@ describe('expiry date', () => {
       expect(validateYear('2014')).toEqual(false);
       expect(validateYear('2015')).toEqual(true);
       expect(validateYear('2016')).toEqual(true);
+    });
+    it('should support 2-digit years', () => {
+      const currentTwoDigitYear = new Date().getFullYear() - 2000; // 15
+      expect(validateYear(String(currentTwoDigitYear - 1))).toEqual(false); // '14' is in the past
+      expect(validateYear(String(currentTwoDigitYear))).toEqual(true); // '15' is the current year
+      expect(validateYear(currentTwoDigitYear + 1)).toEqual(true); // '16' is in the future
+      expect(validateYear('28')).toEqual(true);
+    });
+    it('should return false if the year is more than 50 years in the future', () => {
+      const currentYear = new Date().getFullYear(); // 2015
+      expect(validateYear(currentYear + 50)).toEqual(true);
+      expect(validateYear(currentYear + 51)).toEqual(false);
+      expect(validateYear('99')).toEqual(false); // 2099 is too far in the future
+      expect(validateYear(9999)).toEqual(false);
     });
   });
   describe('errors', () => {
@@ -92,6 +114,24 @@ describe('expiry date', () => {
     });
     it('should return an empty array for a valid month and year', () => {
       expect(errors('5', '2015')).toEqual([]);
+    });
+    it('should return errors for an invalid 2-digit year', () => {
+      const pastTwoDigitYear = String(new Date().getFullYear() - 2000 - 1); // '14'
+      expect(errors('6', pastTwoDigitYear)).toEqual([
+        'Year cannot be in the past',
+        'Month cannot be in the past'
+      ]);
+    });
+    it('should return errors for a year too far in the future', () => {
+      const farFutureYear = String(new Date().getFullYear() + 51); // '2066'
+      expect(errors('6', farFutureYear)).toEqual([
+        'Year is too far in the future'
+      ]);
+    });
+    it('should return an empty array for a valid month and 2-digit year', () => {
+      const currentTwoDigitYear = String(new Date().getFullYear() - 2000); // '15'
+      expect(errors('5', currentTwoDigitYear)).toEqual([]);
+      expect(errors('12', '28')).toEqual([]);
     });
   });
 });

--- a/src/credit-card/expiry-date/expiry-date.ts
+++ b/src/credit-card/expiry-date/expiry-date.ts
@@ -1,8 +1,14 @@
 import {cleanInput} from '../../utils/parsing';
 
+// Convert 2-digit years (MM/YY input) to 4-digit years. Assumes 20xx.
+function normalizeYear(inputYear: string|number){
+  const year = Number(cleanInput(inputYear));
+  return year > 0 && year < 100 ? year + 2000 : year;
+}
+
 export function validateMonth(inputMonth: string|number, inputYear: string|number){
   const month = Number(cleanInput(inputMonth));
-  const year = Number(cleanInput(inputYear));
+  const year = normalizeYear(inputYear);
   const currentDate = new Date();
   return month >= 1 && month <= 12 &&
     (year > currentDate.getFullYear() ||
@@ -10,13 +16,14 @@ export function validateMonth(inputMonth: string|number, inputYear: string|numbe
 }
 
 export function validateYear(inputYear: string|number){
-  const year = Number(cleanInput(inputYear));
-  return year >= (new Date()).getFullYear();
+  const year = normalizeYear(inputYear);
+  const currentYear = (new Date()).getFullYear();
+  return year >= currentYear && year <= currentYear + 50;
 }
 
 export function errors(inputMonth: string|number, inputYear: string|number){
   const month = Number(cleanInput(inputMonth));
-  const year = Number(cleanInput(inputYear));
+  const year = normalizeYear(inputYear);
   let errors: string[] = [];
   if(!month){
     errors.push('Month cannot be blank');
@@ -25,7 +32,7 @@ export function errors(inputMonth: string|number, inputYear: string|number){
     errors.push('Year cannot be blank');
   }
   if(year && !validateYear(year)){
-    errors.push('Year cannot be in the past');
+    errors.push(year > (new Date()).getFullYear() ? 'Year is too far in the future' : 'Year cannot be in the past');
   }
   if(month && !validateMonth(month, year)){
     errors.push('Month cannot be in the past');


### PR DESCRIPTION
## Finding

`src/credit-card/expiry-date/expiry-date.ts:12-15` — `validateYear` compared the raw input against the full current year with no 2-digit-year handling:

```ts
const year = Number(cleanInput(inputYear));
return year >= (new Date()).getFullYear();
```

A donor entering the ubiquitous MM/YY format (`'12'`/`'28'`) gets `28 >= 2026` → `false` → `'Year cannot be in the past'`, and `encrypt()` in `src/credit-card/credit-card.ts` throws `'Credit card details invalid'`. Any consumer site that passes the raw YY value through is **100% declined**. `validateMonth` and `errors()` had the same problem with their year argument. There was also no upper bound, so `9999` or a typo like `2107` validated as a fine expiry year.

## Fix

- Added a small `normalizeYear` helper: a parsed year in `(0, 100)` is treated as `year + 2000`. It is applied consistently in `validateYear`, `validateMonth` (its year argument), and `errors()`.
- **Century pivot choice:** the normalization assumes 20xx. Cards expire at most ~10 years out, so this is correct until ~2100.
- Added an upper bound in `validateYear`: years more than 50 years in the future are rejected (generous — never declines a real card, catches `2107`-style typos). `errors()` reports this as `'Year is too far in the future'`, matching the phrasing style of the existing messages.

## Risk & compatibility

- This change **loosens validation only** for in-range years: inputs that previously failed (2-digit years) now pass; every previously-valid 4-digit input still validates identically.
- The only inputs that newly fail are years more than 50 years in the future (e.g. `2107`, `9999`) — these are never real card expiry dates.
- Note: `tsys.encrypt` sends the year to TSYS as-passed (`MM/<year>`), so consumers submitting YY values will now reach TSYS with `MM/YY` instead of being declined client-side; TSYS accepts the `MM/YY` expiration format.

## Verification

- `yarn lint` — 0 errors (72 pre-existing style warnings, unchanged).
- `npx karma start --browsers ChromeHeadless --single-run` — **148 tests passing** (142 baseline + 6 new), with exactly the 1 known environment failure: tsys "perform live test → should successfully receive a token from TSYS" ("Failed to fetch"), which fails identically on master without network access to TSYS.
- New specs cover: current/past/future 2-digit years through `validateYear` and `validateMonth`, `errors()` for a past 2-digit year, a far-future year, and valid MM/YY combos returning `[]`. Expected values are derived from the spec's mocked clock (`new Date()`), not hardcoded.

_Automated review PR generated with Claude Code — please review carefully before merging._