### PR TITLE
[MEDIUM] TSYS: stop clobbering host window.onload, trim error leakage, document the code-execution trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ cruPayments.creditCard.encrypt('4111111111111111', '123', '03', '2020')
 
 You can pass a valid ES2015 compatible promise to `.toPromise(PromiseConstructor)` to prevent it from failing on browsers without promise implementations. Passing Angular's `$q` works. Providing a polyfill would also work. See: http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-toPromise
 
+## Security model
+
+The TSYS (credit card) integration fetches JavaScript from TSYS's gateway (`jsView` endpoint) over TLS and executes it in the page in order to obtain the tokenization URL, key, and key ID. This means the library — and any page using it — fully trusts TSYS and the TLS channel: code served by that endpoint runs with the same privileges as the host page. The internal `removeAppendChild` filtering is defense-in-depth against TSYS's known script-import pattern, not a security boundary. Future work is to execute the TSYS payload in a sandboxed iframe so it cannot touch the host DOM.
+
 ## API Usage
 
 ### Credit Card

--- a/src/payment-providers/tsys/tsys.spec.ts
+++ b/src/payment-providers/tsys/tsys.spec.ts
@@ -128,8 +128,33 @@ describe('tsys', () => {
           (error: TsysError) => {
             expect(error).toEqual({
               message: 'Error parsing TSYS code',
-              data: jasmine.any(SyntaxError)
+              data: jasmine.any(String) // only the error message is forwarded, not the raw error object
             });
+            done();
+          });
+    });
+
+    it('should restore the host page\'s window.onload handler after executing the TSYS code', (done) => {
+      const hostOnload = () => 'host page onload sentinel';
+      (<any> window).onload = hostOnload;
+      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of("window.onload = function () {}; function getKey() { return '<key>'; } function getKeyId() { return '<keyId>' } function getUrl() { return '<url>' }"));
+      tsys._fetchTsysData()
+        .subscribe(() => {
+          expect(window.onload).toBe(hostOnload);
+          (<any> window).onload = null;
+          done();
+        }, () => done.fail('should not have thrown an error'));
+    });
+
+    it('should restore the host page\'s window.onload handler even when executing the TSYS code throws', (done) => {
+      const hostOnload = () => 'host page onload sentinel';
+      (<any> window).onload = hostOnload;
+      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of('@'));
+      tsys._fetchTsysData()
+        .subscribe(() => done.fail('should have thrown an error'),
+          () => {
+            expect(window.onload).toBe(hostOnload);
+            (<any> window).onload = null;
             done();
           });
     });

--- a/src/payment-providers/tsys/tsys.ts
+++ b/src/payment-providers/tsys/tsys.ts
@@ -70,29 +70,52 @@ function fetchTsysData(){
         };
 
         try {
-          // Execute TSYS code in function. Add return values to get data that is not publicly advertised by TSYS. Call onload to run TSYS error handling if unsuccessful.
-          const tsysData: TsysData = new Function('tsepHandler', `${removeAppendChild(response)}
-          try{
-            return { url: getUrl(), key: getKey(), keyId: getKeyId() };
-          } catch(e){}
-          try{
-            window.onload();
-          } catch(e){}
-          return null;
-          `)(tsepHandler);
+          // SECURITY NOTE: `new Function` below executes the raw JavaScript response fetched from
+          // TSYS's jsView endpoint with full access to this page's globals. Executing this response
+          // means fully trusting TSYS and the TLS channel it was fetched over; `removeAppendChild`
+          // is NOT a security boundary. Future work: execute the TSYS payload inside a sandboxed
+          // iframe so TSYS-served code cannot touch the host DOM.
+          //
+          // The TSYS code assigns `window.onload`, which the wrapper invokes to run TSYS's error
+          // handling. Capture the host page's onload handler first and restore it afterwards so
+          // this library doesn't permanently clobber the host page's own handler.
+          const previousOnload = window.onload;
+          let tsysData: TsysData;
+          try {
+            // Execute TSYS code in function. Add return values to get data that is not publicly advertised by TSYS. Call onload to run TSYS error handling if unsuccessful.
+            tsysData = new Function('tsepHandler', `${removeAppendChild(response)}
+            try{
+              return { url: getUrl(), key: getKey(), keyId: getKeyId() };
+            } catch(e){}
+            try{
+              window.onload();
+            } catch(e){}
+            return null;
+            `)(tsepHandler);
+          } finally {
+            window.onload = previousOnload;
+          }
           if(!tsysData) {
             observer.error({ message: 'TSYS load error', data: 'TSYS did not provide a getUrl, getKey, and/or getKeyId function' });
           }else{
             observer.next(tsysData);
           }
         } catch(e){
-          observer.error({ message: 'Error parsing TSYS code', data: e });
+          // Forward only the error message; the raw error object can embed a chunk of the fetched TSYS source
+          observer.error({ message: 'Error parsing TSYS code', data: e && e.message ? e.message : String(e) });
         }
         observer.complete();
       });
     });
 }
 
+// SECURITY NOTE: this regex strips the `appendChild` statements TSYS uses to import its own
+// scripts into the DOM, purely as defense-in-depth for that specific, known pattern. It is NOT a
+// security boundary: it is trivially bypassed (a statement without a trailing semicolon defeats
+// it, and insertBefore/document.write/innerHTML/etc. are untouched), and the greedy `[^;]*` can
+// even consume legitimate adjacent code back to the previous semicolon. The executed response is
+// trusted as if it were TSYS-authored code delivered over TLS (see fetchTsysData). Future work:
+// sandboxed iframe execution instead of regex filtering.
 function removeAppendChild(code: string){
   return code.replace(/[^;]*appendChild.*?;/g, ''); // Prevent script imports from being added to the DOM
 }


### PR DESCRIPTION
## Findings

`fetchTsysData()` executes the raw JavaScript response from TSYS's `jsView` endpoint via `new Function()` (`src/payment-providers/tsys/tsys.ts:62-93` on master). Three medium-criticality issues:

1. **Host `window.onload` clobbering** (`src/payment-providers/tsys/tsys.ts:78-80` on master): the executed TSYS code assigns `window.onload = ...` and the wrapper invokes it for TSYS error handling — but the assignment was never undone, permanently overwriting the host donation page's own onload handler.
2. **Error detail leak** (`src/payment-providers/tsys/tsys.ts:88-89` on master): on a parse failure, the raw error object was forwarded as `data: e`; a `SyntaxError` message can embed a chunk of the fetched TSYS source, leaking it to whatever consumes/logs the error.
3. **False-confidence sanitizer + undocumented trust boundary** (`src/payment-providers/tsys/tsys.ts:96-98` on master): `removeAppendChild` regex-strips `appendChild` statements but is trivially bypassable (a statement without a trailing semicolon defeats it via ASI; `insertBefore`/`document.write`/`innerHTML` etc. are untouched) and the greedy `[^;]*` can even consume legitimate adjacent code back to the previous semicolon. Nothing documented that executing this response means fully trusting TSYS.

## Fix

- Capture `window.onload` before the `new Function(...)` call and restore it in a `finally` after execution completes. The TSYS-assigned onload is still invoked inside the wrapper exactly as before — only the lasting global mutation is fixed.
- Forward `data: e && e.message ? e.message : String(e)` instead of the raw error object on parse failure.
- `removeAppendChild` is kept (defense-in-depth for the script-import pattern it was written for), with honest comment blocks above it and above the `new Function` call stating that executing the response means fully trusting TSYS + the TLS channel, that the regex is NOT a security boundary, and that sandboxed iframe execution is the future fix.
- Added a `## Security model` section to README.md documenting that the TSYS integration executes code fetched from TSYS's gateway over TLS and inherits that trust.
- New specs assert `window.onload` is restored after `_fetchTsysData` (both success and throw paths); the parse-error spec now expects a message string instead of the raw error object.

## Future work

The real fix is to execute the TSYS payload inside a sandboxed iframe (or equivalent isolated realm) instead of `new Function()` in the host page. Today, anything served by the `jsView` endpoint runs with full access to the donation page's DOM, cookies, and globals — so a compromise of TSYS's gateway or the TLS channel is a compromise of the host page; no regex filtering changes that. A sandboxed approach would load the response into an `<iframe sandbox="allow-scripts">` on a separate origin, run the wrapper there, and pass back only the extracted `{ url, key, keyId }` via `postMessage`, so TSYS-served code can never touch the host DOM. It would involve restructuring `fetchTsysData` around an async message handshake, and carries a host-page CSP caveat: consuming pages would need `frame-src`/`child-src` (and possibly `script-src` for the frame bootstrap) to permit the sandbox frame, which makes it a breaking-ish integration change best done as its own PR.

## Risk & compatibility

- Low risk. The TSYS execution path is unchanged in behavior: the same wrapper runs, the TSYS-assigned onload is still invoked, and `removeAppendChild` still applies. The only behavioral changes are (a) `window.onload` is restored after execution — strictly less surprising for host pages — and (b) the `Error parsing TSYS code` error's `data` is now a string message rather than an Error object. Consumers that matched on `error.data instanceof Error` (unlikely; `error.message` is the documented discriminator) would need to adjust.
- Note: this PR may conflict trivially with PR #52 (CVV stripping), which touches the same file — both are small and easy to rebase.

## Verification

- `yarn lint`: 0 errors (66 pre-existing style warnings, unchanged).
- `npx karma start --browsers ChromeHeadless --single-run`: 144 tests completed (142 baseline + 2 new onload-restoration specs), with exactly the 1 known environment failure: tsys "perform live test > should successfully receive a token from TSYS" ("Failed to fetch").

_Automated review PR generated with Claude Code — please review carefully before merging._
