### PR TITLE
[MEDIUM] Publish TypeScript declarations (types field + declaration build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.3.2",
   "description": "Library for validating and encrypting credit card and bank account info",
   "main": "dist/cru-payments.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "start": "webpack serve",
-    "build": "webpack --mode production",
+    "build": "webpack --mode production && npm run build:types",
+    "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint 'src/**'",
     "test": "karma start",
     "prepublish": "npm run build"

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "rootDir": "src",
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"]
+}


### PR DESCRIPTION
## Finding

**Criticality: medium** — TypeScript consumers get no types from a TypeScript codebase.

The entire library is written in TypeScript, but `package.json` has no `types` field and the webpack build (`webpack.config.js`, three UMD entry points: `cru-payments`, `cru-payments-ba`, `cru-payments-cc`) emits only `.js` bundles and source maps into `dist/`. Any TS consumer importing `@cruglobal/cru-payments` (or the deep `dist/` paths the README documents) falls back to implicit `any` or needs `// @ts-ignore` / a hand-rolled `declare module`.

## Fix

Purely additive packaging change, no source code touched:

- **`tsconfig.types.json`** (new): extends the base `tsconfig.json`, sets `declaration` + `emitDeclarationOnly`, `outDir: dist/types`, `rootDir: src`, includes `src/**/*.ts` and excludes `src/**/*.spec.ts` so spec files never leak into the published types.
- **`package.json`**:
  - `"types": "dist/types/index.d.ts"` — matches `main` (`dist/cru-payments.js` is built from `src/index.ts`).
  - New `"build:types": "tsc -p tsconfig.types.json"` script, chained into the existing build: `"build": "webpack --mode production && npm run build:types"`. So `yarn build` (used by the CI build job and `prepublish`) now produces both bundles and declarations.

Deep-import consumers of the slim bundles (`dist/cru-payments-ba`, `dist/cru-payments-cc`) are partially covered: the corresponding declarations are emitted at `dist/types/bank-account/bank-account.d.ts` and `dist/types/credit-card/credit-card.d.ts`, but module resolution won't pair them with the deep `dist/*.js` paths automatically. Wiring those up (e.g. via an `exports`/`typesVersions` map) is left out to keep this PR simple.

## Risk & compatibility

- **Purely additive** — no runtime code, bundle contents, or public API changed. JS consumers are unaffected; TS consumers gain types.
- `.npmignore` only excludes `.idea`, `.github`, `coverage`, so `dist/types/**` ships with the package.
- CI artifact flow unchanged: the build job still just runs `yarn build`; the deploy job's `npm publish` runs `prepublish` → `npm run build`, which now also emits the declarations before publishing.
- `tsc -p tsconfig.types.json` adds a type-check pass over `src/` (specs excluded) to the build — it compiles cleanly today.

## Verification

- `yarn build` succeeds and emits 13 `.d.ts` files under `dist/types/` mirroring `src/`.
- Emitted `dist/types/index.d.ts`:
  ```ts
  import * as bankAccount from './bank-account/bank-account';
  import * as creditCard from './credit-card/credit-card';
  export { bankAccount, creditCard };
  ```
- Consumer smoke test: a throwaway project with the built package symlinked into `node_modules/@cruglobal/cru-payments` and a `check.ts` doing `import * as cruPayments from '@cruglobal/cru-payments'` and exercising `creditCard.card.validate.all(...)`, `creditCard.cvv.errors(...)`, `bankAccount.routingNumber.validate.all(...)`, and `creditCard.init(...)` passed `tsc --noEmit` under `strict: true` (throwaway deleted before commit).
- `yarn lint`: 0 errors (67 pre-existing warnings).
- `npx karma start --browsers ChromeHeadless --single-run`: 142 tests passing, 1 failure — the known environment-only TSYS live test ("should successfully receive a token from TSYS" / "Failed to fetch"), matching baseline.

_Automated review PR generated with Claude Code — please review carefully before merging._