### PR TITLE
[MEDIUM] Migrate rxjs 5 (EOL 2018) → 7, keeping the Observable public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "es6-promise": "^4.0.5",
     "jsencrypt": "3.1.0",
-    "rxjs": "^5.0.3",
+    "rxjs": "^7.8.2",
     "whatwg-fetch": "^2.0.1"
   },
   "devDependencies": {

--- a/src/bank-account/bank-account.spec.ts
+++ b/src/bank-account/bank-account.spec.ts
@@ -1,8 +1,6 @@
 import * as bankAccount from './bank-account';
 import * as ccp from '../payment-providers/ccp/ccp';
-import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
+import {of, throwError} from 'rxjs';
 
 describe('bank account', () => {
 
@@ -53,7 +51,7 @@ describe('bank account', () => {
 
   describe('encrypt', () => {
     beforeEach(function() {
-      spyOn(ccp, 'encrypt').and.returnValue(Observable.of('<encrypted account number>'));
+      spyOn(ccp, 'encrypt').and.returnValue(of('<encrypted account number>'));
     });
     it('should return an error if something is invalid', (done) => {
       bankAccount.encrypt('1')
@@ -74,7 +72,7 @@ describe('bank account', () => {
         });
     });
     it('should return an errored Observable if encryption was unsuccessful', (done) => {
-      (<jasmine.Spy> ccp.encrypt).and.returnValue(Observable.throw('some error'));
+      (<jasmine.Spy> ccp.encrypt).and.returnValue(throwError(() => 'some error'));
       bankAccount.encrypt('123456')
         .subscribe(() => {
           done.fail('Observable should have thrown an error');

--- a/src/bank-account/bank-account.ts
+++ b/src/bank-account/bank-account.ts
@@ -1,5 +1,4 @@
-import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/observable/throw';
+import {throwError} from 'rxjs';
 import {cleanInput} from '../utils/parsing';
 
 
@@ -34,7 +33,7 @@ export function validate(routingNumberInput: string|number, accountNumberInput: 
 
 export function encrypt(accountNumberInput: string|number){
   if(!accountNumber.validate.all(accountNumberInput)){
-    return Observable.throw('Bank account number invalid');
+    return throwError(() => 'Bank account number invalid');
   }
   return bankAccountEncrypt(cleanInput(accountNumberInput));
 }

--- a/src/credit-card/credit-card.spec.ts
+++ b/src/credit-card/credit-card.spec.ts
@@ -1,8 +1,6 @@
 import * as creditCard from './credit-card';
 import * as tsys from '../payment-providers/tsys/tsys';
-import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
+import {of, throwError} from 'rxjs';
 
 describe('credit card', () => {
 
@@ -85,7 +83,7 @@ describe('credit card', () => {
     beforeEach(function() {
       jasmine.clock().install();
       jasmine.clock().mockDate(new Date(2015, 3, 1)); // Apr 01 2015
-      spyOn(tsys, 'encrypt').and.returnValue(Observable.of('<tsys card token>'));
+      spyOn(tsys, 'encrypt').and.returnValue(of('<tsys card token>'));
     });
     afterEach(function() {
       jasmine.clock().uninstall();
@@ -118,7 +116,7 @@ describe('credit card', () => {
         });
     });
     it('should return an errored Observable if encryption was unsuccessful', (done) => {
-      (<jasmine.Spy> tsys.encrypt).and.returnValue(Observable.throw('some error'));
+      (<jasmine.Spy> tsys.encrypt).and.returnValue(throwError(() => 'some error'));
       creditCard.encrypt('4111111111111111', '123', 4, 2015)
         .subscribe(() => {
           done.fail('Observable should have thrown an error');

--- a/src/credit-card/credit-card.ts
+++ b/src/credit-card/credit-card.ts
@@ -1,5 +1,4 @@
-import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/observable/throw';
+import {throwError} from 'rxjs';
 import {cleanInput} from '../utils/parsing';
 import * as cardNumberModule from './card-number/card-number';
 import {validateMinLength as cvvValidateMinLength, validateMaxLength as cvvValidateMaxLength, validateCardTypeLength as cvvValidateCardTypeLength, validateAll as cvvValidateAll, errors as cvvErrors} from './cvv/cvv';
@@ -51,7 +50,7 @@ export function validate(cardNumber: string|number, cvvInput: string|number, mon
 
 export function encrypt(cardNumber: string|number, cvv: string|number, month: string|number, year: string|number){
   if(!validate(cardNumber, cvv, month, year)){
-    return Observable.throw('Credit card details invalid');
+    return throwError(() => 'Credit card details invalid');
   }
   // allow CVV to be optional if it is null
   return creditCardEncrypt(cleanInput(cardNumber), cvv === null ? null : cleanInput(cvv), Number(cleanInput(month)), Number(cleanInput(year)));

--- a/src/payment-providers/ccp/ccp.ts
+++ b/src/payment-providers/ccp/ccp.ts
@@ -1,10 +1,5 @@
-import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/observable/from';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/operator/catch';
+import {Observable, from, of, throwError} from 'rxjs';
+import {catchError, map, mergeMap} from 'rxjs/operators';
 
 import {Promise} from 'es6-promise';
 if (!(<any> window).Promise) {
@@ -20,41 +15,43 @@ const stagingKeyUri = 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption
 let ccpKeyObservable: Observable<string>;
 
 export function init(env: string, backupKey?: string){
-  ccpKeyObservable = Observable.from((<any> window).fetch(env === 'production' ? prodKeyUri : stagingKeyUri))
-    .mergeMap((response: Response) => {
+  ccpKeyObservable = from((<any> window).fetch(env === 'production' ? prodKeyUri : stagingKeyUri)).pipe(
+    mergeMap((response: Response) => {
       if (response.ok) {
-        return Observable.from(response.text());
+        return from(response.text());
       }else{
-        return Observable.throw(response.statusText);
+        return throwError(() => response.statusText);
+      }
+    }),
+    catchError(error => {
+      if(backupKey){
+        return of(backupKey);
+      }else{
+        return throwError(() => 'There was an error retrieving the key from CCP and no backup key was provided: ' + error);
       }
     })
-    .catch(error => {
-      if(backupKey){
-        return Observable.of(backupKey);
-      }else{
-        return Observable.throw('There was an error retrieving the key from CCP and no backup key was provided: ' + error);
-      }
-    });
+  );
 }
 
 export function encrypt(accountNumber: string){
   if(!ccpKeyObservable){
-    return Observable.throw('init must be called first');
+    return throwError(() => 'init must be called first');
   }
 
-  return ccpKeyObservable
-    .map(key => {
+  return ccpKeyObservable.pipe(
+    map(key => {
       const encryptor = new JSEncrypt();
       encryptor.setKey(key);
       return encryptor.encrypt(accountNumber);
-    })
-    .mergeMap(encryptedNumber => {
+    }),
+    mergeMap(encryptedNumber => {
       if (encryptedNumber !== false) {
-        return Observable.of(encryptedNumber);
+        return of(encryptedNumber);
       }else{
-        return Observable.throw('Error encrypting bank account number');
+        return throwError(() => 'Error encrypting bank account number');
       }
-    });
+    })
+  );
 }
 
 function clear(){

--- a/src/payment-providers/tsys/tsys.spec.ts
+++ b/src/payment-providers/tsys/tsys.spec.ts
@@ -1,6 +1,6 @@
 import * as tsys from './tsys';
 
-import {Observable} from 'rxjs/Observable';
+import {of} from 'rxjs';
 import * as fetchMock from 'fetch-mock';
 
 /* eslint-disable no-undef */
@@ -83,7 +83,7 @@ describe('tsys', () => {
       tsys.init('staging', 'deviceId', 'manifest');
     });
     it('should get the staging url, key, and keyId for tokenization', (done) => {
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of("function getKey() { return '<key>'; } function getKeyId() { return '<keyId>' } function getUrl() { return '<url>' }"));
+      spyOn(tsys, '_makeRequest').and.returnValue(of("function getKey() { return '<key>'; } function getKeyId() { return '<keyId>' } function getUrl() { return '<url>' }"));
       tsys._fetchTsysData()
         .subscribe((data: tsys.TsysData) => {
           expect(tsys._makeRequest).toHaveBeenCalledWith(
@@ -102,7 +102,7 @@ describe('tsys', () => {
     });
 
     it('should get the production url, key, and keyId for tokenization', (done) => {
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of("function getKey() { return '<key>'; } function getKeyId() { return '<keyId>' } function getUrl() { return '<url>' }"));
+      spyOn(tsys, '_makeRequest').and.returnValue(of("function getKey() { return '<key>'; } function getKeyId() { return '<keyId>' } function getUrl() { return '<url>' }"));
       tsys.init('production', 'deviceId', 'manifest');
       tsys._fetchTsysData()
         .subscribe((data: tsys.TsysData) => {
@@ -122,7 +122,7 @@ describe('tsys', () => {
     });
 
     it('should handle an error parsing the TSYS code', (done) => {
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of('@'));
+      spyOn(tsys, '_makeRequest').and.returnValue(of('@'));
       tsys._fetchTsysData()
         .subscribe(() => {},
           (error: TsysError) => {
@@ -135,7 +135,7 @@ describe('tsys', () => {
     });
 
     it('should handle a missing function', (done) => {
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of(''));
+      spyOn(tsys, '_makeRequest').and.returnValue(of(''));
       tsys._fetchTsysData()
         .subscribe(() => {},
           (error: TsysError) => {
@@ -148,7 +148,7 @@ describe('tsys', () => {
     });
 
     it('should handle a error passed by the TSYS library', (done) => {
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of('window.onload = function () {var eEvent = new Object();eEvent.responseCode="TSEPERR911";eEvent.status="FAIL";eEvent.message="Authentication Failed"; try{tsepHandler("ErrorEvent", eEvent);}catch(e){}};'));
+      spyOn(tsys, '_makeRequest').and.returnValue(of('window.onload = function () {var eEvent = new Object();eEvent.responseCode="TSEPERR911";eEvent.status="FAIL";eEvent.message="Authentication Failed"; try{tsepHandler("ErrorEvent", eEvent);}catch(e){}};'));
       tsys._fetchTsysData()
         .subscribe(() => {},
           (error: TsysError) => {
@@ -171,7 +171,7 @@ describe('tsys', () => {
     beforeEach(() => {
       validKey = '-----BEGIN PUBLIC KEY-----MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCH+HoBX8drfBn88Z49gYnK7Z9FVbbBg76lXHfoEUSPHLuzQ9ws4fR3PzDcKO3VIb6/9g3VBfFvMLrdimAGRwqmm4kk/JnnDFWF/HBVmncRTtDkNPuEN15+XJSB8RcvUVQ7s8gkutCU/w2ZXzI5+7XpEyX08Ao7f2IKuncBQmDQJwIDAQAB-----END PUBLIC KEY-----';
 
-      spyOn(tsys, '_fetchTsysData').and.returnValue(Observable.of({
+      spyOn(tsys, '_fetchTsysData').and.returnValue(of({
         url: '<url>',
         key: validKey,
         keyId: '<keyId>'
@@ -211,7 +211,7 @@ describe('tsys', () => {
         transactionID: '6417599',
         tsepToken: 'aNWEmSu7RRF1000'
       };
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of(tokenObj));
+      spyOn(tsys, '_makeRequest').and.returnValue(of(tokenObj));
       tsys.encrypt('1234567890123', '123', 12, 2015)
         .subscribe(data => {
           expect(tsys._makeRequest).toHaveBeenCalledWith(
@@ -233,7 +233,7 @@ describe('tsys', () => {
     });
 
     it('should convert month to a string', (done) => {
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of({ status: 'PASS' }));
+      spyOn(tsys, '_makeRequest').and.returnValue(of({ status: 'PASS' }));
       tsys.encrypt('1234567890123', '123', 1, 2015)
         .subscribe(data => {
           expect(tsys._makeRequest).toHaveBeenCalledWith(
@@ -255,7 +255,7 @@ describe('tsys', () => {
     });
 
     it('should handle an invalid key', (done) => {
-      (<jasmine.Spy> tsys._fetchTsysData).and.returnValue(Observable.of({
+      (<jasmine.Spy> tsys._fetchTsysData).and.returnValue(of({
         url: '<url>',
         key: '<key>',
         keyId: '<keyId>'
@@ -270,7 +270,7 @@ describe('tsys', () => {
     });
 
     it('should handle a error when TSYS status is not pass', (done) => {
-      spyOn(tsys, '_makeRequest').and.returnValue(Observable.of({ status: 'FAILURE' }));
+      spyOn(tsys, '_makeRequest').and.returnValue(of({ status: 'FAILURE' }));
       tsys.encrypt('1234567890123', '123', 12, 2015)
         .subscribe(() => {},
           error => {

--- a/src/payment-providers/tsys/tsys.ts
+++ b/src/payment-providers/tsys/tsys.ts
@@ -1,12 +1,7 @@
-import {Observable} from 'rxjs/Observable';
+import {Observable, from, of, throwError} from 'rxjs';
 // eslint-disable-next-line no-unused-vars
-import {Observer} from 'rxjs/Observer';
-import 'rxjs/add/observable/from';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/operator/toPromise';
+import {Observer} from 'rxjs';
+import {catchError, mergeMap} from 'rxjs/operators';
 
 import {Promise} from 'es6-promise';
 if (!(<any> window).Promise) {
@@ -40,15 +35,17 @@ export function init(_env: string, _deviceId: string, _manifest: string){
 }
 
 function makeRequest(url: RequestInfo, init: RequestInit, bodyFn: Function, action: string){
-  return Observable.from((<any> window).fetch(url, init))
-    .catch((error: Response) => Observable.throw({ message: `Network error while ${action}`, data: error }))
-    .mergeMap((response: Response) => {
+  return from((<any> window).fetch(url, init)).pipe(
+    catchError((error: Response) => throwError(() => ({ message: `Network error while ${action}`, data: error }))),
+    mergeMap((response: Response) => {
       if (response.ok) {
-        return Observable.from(bodyFn(response));
+        return from(bodyFn(response));
       }
-      return Observable.from(response.text())
-        .mergeMap(body => Observable.throw({ message: `Server error while ${action}`, data: { status: response.status, statusText: response.statusText, body: body } }));
-    });
+      return from(response.text()).pipe(
+        mergeMap(body => throwError(() => ({ message: `Server error while ${action}`, data: { status: response.status, statusText: response.statusText, body: body } })))
+      );
+    })
+  );
 }
 
 function fetchTsysData(){
@@ -59,7 +56,7 @@ function fetchTsysData(){
     (request: Request) => request.text(),
     'loading TSYS library'
   )
-    .mergeMap((response: string) => {
+    .pipe(mergeMap((response: string) => {
       return new Observable((observer: Observer<any>) => {
         // Watch tsepHandler for errors loading the TSYS library
         const tsepHandler = (eventType: string, event: any) => {
@@ -90,7 +87,7 @@ function fetchTsysData(){
         }
         observer.complete();
       });
-    });
+    }));
 }
 
 function removeAppendChild(code: string){
@@ -99,14 +96,14 @@ function removeAppendChild(code: string){
 
 export function encrypt(cardNumber: string, cvv: string, month: number, year: number): Observable<any> {
   if(!deviceId){
-    return Observable.throw({ message: 'Device ID not set', data: 'init needs to be called first' });
+    return throwError(() => ({ message: 'Device ID not set', data: 'init needs to be called first' }));
   }
   if(!manifest){
-    return Observable.throw({ message: 'Manifest not set', data: 'init needs to be called first' });
+    return throwError(() => ({ message: 'Manifest not set', data: 'init needs to be called first' }));
   }
 
   return exports._fetchTsysData()
-    .mergeMap((tsysData: TsysData) => {
+    .pipe(mergeMap((tsysData: TsysData) => {
       let monthString = String(month);
       monthString = monthString.length === 1 ? '0' + monthString : monthString;
       const expiryDate = monthString + '/' + String(year);
@@ -116,7 +113,7 @@ export function encrypt(cardNumber: string, cvv: string, month: number, year: nu
       encryptor.setKey(tsysData.key);
       const encryptedNumber = encryptor.encrypt(cardNumber);
       if (encryptedNumber === false) {
-        return Observable.throw({ message: 'Encryption error', data: 'Could not encrypt the card number with the key provided by TSYS' });
+        return throwError(() => ({ message: 'Encryption error', data: 'Could not encrypt the card number with the key provided by TSYS' }));
       }
 
       // Request format not publicly advertised by TSYS. /generateTsepToken url fragment, method, and request body format extracted from tsep.js.
@@ -140,13 +137,13 @@ export function encrypt(cardNumber: string, cvv: string, month: number, year: nu
         (request: Request) => request.json(),
         'performing tokenization'
       );
-    })
-    .mergeMap((response: any) => {
+    }),
+    mergeMap((response: any) => {
       if(response.status === 'PASS'){
-        return Observable.of(response);
+        return of(response);
       }
-      return Observable.throw({ message: 'Tokenization error', data: response });
-    });
+      return throwError(() => ({ message: 'Tokenization error', data: response }));
+    }));
 }
 
 // For testing

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,9 @@ module.exports = {
   module: {
     rules: [
       // all files with a `.ts` extension but not `.spec.ts` will be handled by `ts-loader`
-      { test: /^(?!.*\.spec\.ts$).*\.ts$/, loader: 'ts-loader' }
+      // module is overridden to es2015 (tsconfig.json uses commonjs for karma-typescript)
+      // so webpack can tree-shake rxjs's ES module build
+      { test: /^(?!.*\.spec\.ts$).*\.ts$/, loader: 'ts-loader', options: { compilerOptions: { module: 'es2015' } } }
     ]
   },
   devtool: "source-map",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5456,12 +5456,12 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^5.0.3:
-  version "5.5.12"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
-  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
+rxjs@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
-    symbol-observable "1.0.1"
+    tslib "^2.1.0"
 
 safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -6036,11 +6036,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-  integrity sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==
-
 table@^6.0.9:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"
@@ -6195,6 +6190,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## Finding

**Criticality: medium.** `rxjs ^5.0.3` (resolving to 5.5.12) is a runtime dependency that has been end-of-life since ~2018 — no bug or security fixes. The code used the v5 prototype-patching style (`rxjs/add/observable/from`, `.mergeMap(...)`, `.catch(...)`), which has been removed from modern rxjs. Current rxjs is 7.x.

## Fix

- Bump `rxjs` to `^7.8.2` (latest 7.x — deliberately **not** going past 7; this is the conservative target).
- Mechanical migration to the rxjs 6+ style:
  - Named creation functions from `'rxjs'`: `from`, `of`, `throwError(() => err)` (factory form — the direct-value form is deprecated in 7).
  - Pipeable operators from `'rxjs/operators'`: `catchError`, `map`, `mergeMap` via `.pipe(...)`.
  - Dropped the `rxjs/add/operator/toPromise` import in `tsys.ts` — it was dead code (nothing in src calls `.toPromise()`).
- Spec files updated the same way. The `exports._makeRequest` / `exports._fetchTsysData` self-reference mocking pattern in `tsys.ts`/`ccp.ts` is preserved untouched.
- `webpack.config.js`: ts-loader now overrides `module: 'es2015'` for the bundle build only (tsconfig stays `commonjs` for karma-typescript), so webpack can tree-shake rxjs 7's ESM build. Without this the bundle grew to ~185 KB; with it the main bundle **shrinks** from 111,929 → 100,075 bytes (−11.8 KB, ~−10.6%).
- No karma/karma-typescript config changes were needed — karma-typescript 5.5.3 + the existing es6-transform bundle rxjs 7 fine.

## Risk & compatibility

Being explicit and honest here:

- **Consumers now receive rxjs 7 Observables.** Sites that pass these Observables into their own rxjs 5/6 operator chains, or that `instanceof`-check against their own rxjs copy, may need attention. rxjs 7 Observables interop via `Symbol.observable` in most cases, but it is not guaranteed for every pattern. **Recommend releasing this as a major version.**
- **Public API shape is unchanged**: `init()`/`encrypt()` signatures and Observable returns are identical; UMD export shape verified before/after (`['bankAccount','creditCard']`, same keys on each).
- The README-documented two-callback `.subscribe(success, error)` usage **keeps working** in rxjs 7, but it is deprecated upstream (slated for removal in a later major); the documented `.toPromise()` is likewise deprecated-but-working. Documented usage was intentionally left as-is.
- **Merge conflicts expected** with other open review PRs touching `tsys.ts`/`ccp.ts` (#52, #54, and the tsys-hardening PR) — whichever merges last rebases.

## Verification

- `npx eslint --resolve-plugins-relative-to . 'src/**'` → **0 errors** (67 pre-existing jasmine style warnings). Note: plain `yarn lint` hit a duplicate `eslint-plugin-jasmine` resolution error in the nested review worktree, hence the flag.
- `npx karma start --browsers ChromeHeadless --single-run` → **142 tests passing, 1 failure** — exactly the known environment failure: tsys `perform live test → should successfully receive a token from TSYS` (`Failed to fetch`), unchanged from baseline.
- `yarn build` succeeds; UMD export shape identical before/after; spot-checked that `creditCard.encrypt(...)` still returns an object with `.subscribe` and that the two-callback error path fires.
- Main bundle: 111,929 → 100,075 bytes (−10.6%).

_Automated review PR generated with Claude Code — please review carefully before merging._