### PR TITLE
[LOW] Luhn check: return false for empty/non-digit input instead of true

### DIFF
--- a/src/credit-card/card-number/card-number.spec.ts
+++ b/src/credit-card/card-number/card-number.spec.ts
@@ -68,6 +68,11 @@ describe('card number', () => {
       expect(cardNumber.validateChecksum('123')).toEqual(true);
       expect(luhn.luhnCheck).toHaveBeenCalledWith('123');
     });
+    it('should return false for empty or non-digit input', () => {
+      expect(cardNumber.validateChecksum('')).toEqual(false);
+      expect(cardNumber.validateChecksum('----')).toEqual(false);
+      expect(cardNumber.validateChecksum('abcd')).toEqual(false);
+    });
   });
   describe('validateAll', () => {
     it('should clean input', () => {

--- a/src/credit-card/card-number/card-number.ts
+++ b/src/credit-card/card-number/card-number.ts
@@ -55,7 +55,7 @@ export function errors(input: string|number){
   if(validateKnownType(cardNumber) && !validateTypeLength(cardNumber)){
     errors.push(`This is an invalid ${cardTypes.getCardTypeName(cardNumber)} number. It should have ${cardTypes.expectedLength(cardNumber).join(' or ')} digits but the number entered has ${cardNumber.length}.`);
   }
-  if(!validateChecksum(cardNumber)){
+  if(cardNumber && !validateChecksum(cardNumber)){
     errors.push('Card number is invalid. At least one digit was entered incorrectly.');
   }
   return errors;

--- a/src/credit-card/card-number/utils/luhn-check.spec.ts
+++ b/src/credit-card/card-number/utils/luhn-check.spec.ts
@@ -14,4 +14,7 @@ describe('luhnCheck', () => {
     expect(luhnCheck('5111111111111111')).toEqual(false);
     expect(luhnCheck('4408041234567892')).toEqual(false);
   });
+  it('should return false for an empty string', () => {
+    expect(luhnCheck('')).toEqual(false);
+  });
 });

--- a/src/credit-card/card-number/utils/luhn-check.ts
+++ b/src/credit-card/card-number/utils/luhn-check.ts
@@ -3,6 +3,9 @@
 const luhnArray = [0, 2, 4, 6, 8, 1, 3, 5, 7, 9];
 
 export function luhnCheck(cardNumber: string) {
+  if (cardNumber.length === 0) {
+    return false;
+  }
   let counter = 0;
   let odd = false;
   for (let i = cardNumber.length - 1; i >= 0; --i) {


### PR DESCRIPTION
## Finding

`src/credit-card/card-number/utils/luhn-check.ts:13` — for an empty string the digit loop never runs, so `counter` stays 0 and `0 % 10 === 0` returns `true`. Since `cleanInput` strips all non-digit characters before the check, the public standalone checksum API returned misleading results:

- `creditCard.card.validate.checksum('')` → `true`
- `creditCard.card.validate.checksum('----')` → `true`
- `creditCard.card.validate.checksum('abcd')` → `true`

`validateAll` was already protected by its `!!cardNumber` guard (`card-number.ts:32`), so only the standalone checksum API was affected.

## Fix

- `luhnCheck` now returns `false` when the (post-clean) input is empty.
- The checksum branch in `errors()` (`card-number.ts:58`) is guarded on non-blank input so blank input still reports only 'Card number cannot be blank' plus the length/type errors — the existing `errors('')` contract codified in `card-number.spec.ts` is unchanged.
- Regression tests added: `validateChecksum('') === false`, `validateChecksum('----') === false`, `validateChecksum('abcd') === false`, and `luhnCheck('') === false`. The existing `errors('')` spec continues to pass unmodified.

## Risk & compatibility

Low. Behavior changes only for the standalone checksum API on degenerate input (empty or all-non-digit strings) — it now returns `false` instead of `true`. `validateAll`, `errors()`, and all valid/invalid real card number results are unchanged.

## Verification

- `yarn lint`: 0 errors (67 pre-existing warnings, identical to master baseline).
- `npx karma start --browsers ChromeHeadless --single-run`: 144 tests completed, 1 failed — the failure is the known environment-only TSYS live test ('should successfully receive a token from TSYS', 'Failed to fetch'), matching the master baseline of 142 passing + that same failure.

_Automated review PR generated with Claude Code — please review carefully before merging._