### PR TITLE
[LOW] Tests: fix copy-paste assertions that tested the wrong function

### DIFF
--- a/src/bank-account/account-number/account-number.spec.ts
+++ b/src/bank-account/account-number/account-number.spec.ts
@@ -35,12 +35,12 @@ describe('account number', () => {
       expect(accountNumber.validateAll('12345678901234567')).toEqual(true);
     });
     it('should return false for invalid numbers', () => {
-      expect(accountNumber.validateMinLength(undefined)).toEqual(false);
-      expect(accountNumber.validateMinLength(null)).toEqual(false);
+      expect(accountNumber.validateAll(undefined)).toEqual(false);
+      expect(accountNumber.validateAll(null)).toEqual(false);
       expect(accountNumber.validateAll('')).toEqual(false);
       expect(accountNumber.validateAll('1')).toEqual(false);
-      expect(accountNumber.validateMaxLength('123456789012345678')).toEqual(false);
-      expect(accountNumber.validateMaxLength('12345678901234567890')).toEqual(false);
+      expect(accountNumber.validateAll('123456789012345678')).toEqual(false);
+      expect(accountNumber.validateAll('12345678901234567890')).toEqual(false);
     });
   });
   describe('errors', () => {

--- a/src/credit-card/cvv/cvv.spec.ts
+++ b/src/credit-card/cvv/cvv.spec.ts
@@ -87,8 +87,8 @@ describe('cvv', () => {
       expect(cvv.validateAll('1234')).toEqual(true);
       expect(cvv.validateAll(9876)).toEqual(true);
       expect(cvv.validateAll('987')).toEqual(true);
-      expect(cvv.validateCardTypeLength(1234, 'American Express')).toEqual(true);
-      expect(cvv.validateCardTypeLength(123, 'Visa')).toEqual(true);
+      expect(cvv.validateAll(1234, 'American Express')).toEqual(true);
+      expect(cvv.validateAll(123, 'Visa')).toEqual(true);
     });
     it('should return false if cvv is invalid', () => {
       expect(cvv.validateAll(undefined)).toEqual(false);
@@ -100,8 +100,8 @@ describe('cvv', () => {
       expect(cvv.validateAll('12345')).toEqual(false);
       expect(cvv.validateAll('123456')).toEqual(false);
       expect(cvv.validateAll(1234567)).toEqual(false);
-      expect(cvv.validateCardTypeLength(123, 'American Express')).toEqual(false);
-      expect(cvv.validateCardTypeLength(1234, 'Visa')).toEqual(false);
+      expect(cvv.validateAll(123, 'American Express')).toEqual(false);
+      expect(cvv.validateAll(1234, 'Visa')).toEqual(false);
     });
   });
   describe('errors', () => {


### PR DESCRIPTION
## Finding
Copy-paste bugs left several assertions inside `validateAll` describe blocks calling a different function, so those `validateAll` cases were never actually tested:

- `src/bank-account/account-number/account-number.spec.ts:38-39` — called `validateMinLength(undefined)` / `validateMinLength(null)` inside the `validateAll` "should return false" block.
- `src/bank-account/account-number/account-number.spec.ts:42-43` — called `validateMaxLength('123456789012345678')` / `validateMaxLength('12345678901234567890')` in the same block. Net effect: `validateAll` was never tested with `undefined`, `null`, or over-length inputs.
- `src/credit-card/cvv/cvv.spec.ts:90-91` — called `validateCardTypeLength(1234, 'American Express')` / `validateCardTypeLength(123, 'Visa')` inside the `validateAll` "should return true" block.
- `src/credit-card/cvv/cvv.spec.ts:103-104` — called `validateCardTypeLength(123, 'American Express')` / `validateCardTypeLength(1234, 'Visa')` inside the `validateAll` "should return false" block.

The other spec files (card-number.spec.ts, routing-number.spec.ts, expiry-date.spec.ts, bank-account.spec.ts, credit-card.spec.ts) were checked for the same pattern and are clean.

## Fix
Each assertion now calls `validateAll`, the function its describe block claims to test. All expected values were verified against the implementations and remain unchanged:

- `account-number.ts`: `validateAll` returns false for `undefined`/`null` (cleanInput strips them to `''`) and for 18+/20-digit inputs (max length 17).
- `cvv.ts`: `validateAll(1234, 'American Express')` and `validateAll(123, 'Visa')` are true; `validateAll(123, 'American Express')` and `validateAll(1234, 'Visa')` are false (Amex CVV length 4, Visa 3).

No corrected assertion exposed a production bug — `validateAll` behaves as the tests intended.

## Risk & compatibility
Test-only change; no production code modified. The corrected assertions now cover previously untested `validateAll` paths (empty/null and over-length account numbers, card-type-specific CVV lengths through `validateAll`).

## Verification
- `yarn lint`: 0 errors (67 pre-existing warnings, untouched).
- `npx karma start --browsers ChromeHeadless --single-run`: 142 tests passing, 1 failure — the known environment-only failure (tsys "perform live test → should successfully receive a token from TSYS", "Failed to fetch"), matching baseline.

_Automated review PR generated with Claude Code — please review carefully before merging._