### PR TITLE
[LOW] Slim the published npm package (files field) and fix deprecated prepublish hook

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-.idea
-.github
-coverage

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.3.2",
   "description": "Library for validating and encrypting credit card and bank account info",
   "main": "dist/cru-payments.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "start": "webpack serve",
     "build": "webpack --mode production",
     "lint": "eslint 'src/**'",
     "test": "karma start",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Findings

1. **No `files` field in package.json.** `npm pack --dry-run` (after a fresh `yarn build`) shipped 42 files / 2.0 MB unpacked, including every `*.spec.ts`, all of `src/`, `webpack.config.js`, `tsconfig.json`, `karma.conf.js`, and `yarn.lock`. The existing `.npmignore` only excluded `.idea`/`.github`/`coverage`.
2. **`"prepublish": "npm run build"` uses the deprecated lifecycle hook.** Modern npm does not run `prepublish` during `npm publish` at all — and the CI deploy job publishes with modern npm (`npm install --global npm@latest && npm publish --access public`), not `yarn publish`. The only reason `dist/` existed at publish time is that yarn 1 happens to run `prepublish` as part of its `yarn install` lifecycle in the deploy job — an accidental, fragile dependency.

## Fix

- Add `"files": ["dist"]` to package.json. `README.md`, `LICENSE*`, and `package.json` are always included automatically by npm.
- Delete `.npmignore` (superseded by the `files` allowlist; keeping both is a known footgun).
- Rename `prepublish` → `prepublishOnly`, which npm runs explicitly before `npm publish` — so the build now happens at publish time by design instead of as an install side effect.

**Why not keep `src/` for source-map debugging?** The webpack source maps embed full `sourcesContent` (all 82 sources, including all 13 `src/*.ts` files), and their `sources` entries are `webpack://` URLs that never resolve to packaged file paths anyway. Shipping `src/` adds nothing for consumers. The `.js.map` files themselves are kept (harmless, useful).

**Compatibility with #59:** the `files` entry covers everything under `dist/`, so the `dist/types` output added by #59 is included automatically — no conflict.

### `npm pack --dry-run` before/after

| | Before | After |
|---|---|---|
| Total files | 42 | 8 |
| Unpacked size | 2.0 MB | 1.9 MB |
| Tarball size | 481.5 kB | 464.4 kB |

After: `README.md`, `package.json`, and the six `dist/cru-payments{,-cc,-ba}.js{,.map}` files. (Size is dominated by the three ~510 kB maps, intentionally retained; the win is dropping 34 spec/source/config files from the public artifact.)

## Risk & compatibility

- Consumers deep-importing anything under `dist/*` are unaffected — all of `dist` still ships, including future additions like `dist/types`.
- Anyone importing a spec, `src/*.ts`, or a config file from the published package would break — implausible for a browser payment-validation library (specs were never compiled output, and `main` points at `dist/`).
- CI deploy flow verified in `.github/workflows/ci.yml`: the deploy job runs `yarn install` then `npm publish --access public` with latest npm. `prepublishOnly` is the documented npm hook that runs before publish, so `dist/` is built at publish time. (Yarn 1's `yarn publish` also runs `prepublishOnly`, so the hook is safe under either publisher.) The separate `build` CI job (`yarn build`) is unaffected.

## Verification

- `npm pack --dry-run` after the change: `dist/` present, specs/configs/`src`/`yarn.lock` gone (table above).
- `yarn lint`: 0 errors (67 pre-existing warnings, untouched).
- `npx karma start --browsers ChromeHeadless --single-run`: 142 tests passed, 1 failure — the known environment-dependent tsys live test ("Failed to fetch"), identical to the baseline on master.

_Automated review PR generated with Claude Code — please review carefully before merging._