### PR TITLE
[LOW] Correct card-brand BIN ranges (JCB 3528 boundary, UnionPay 622126–622925, modern Diners Club)

### DIFF
--- a/src/credit-card/card-number/card-number.spec.ts
+++ b/src/credit-card/card-number/card-number.spec.ts
@@ -112,6 +112,14 @@ describe('card number', () => {
       expect(cardNumber.validateAll('30307967235998')).toEqual(true);
       expect(cardNumber.validateAll('30028342701708')).toEqual(true);
       expect(cardNumber.validateAll('30151350318072')).toEqual(true);
+      expect(cardNumber.validateAll('3600000000000008')).toEqual(true);
+      expect(cardNumber.validateAll('3900000000000005')).toEqual(true);
+      expect(cardNumber.validateAll('3095000000000000')).toEqual(true);
+      // JCB (processed as Discover)
+      expect(cardNumber.validateAll('3528000000000007')).toEqual(true);
+      // UnionPay (processed as Discover)
+      expect(cardNumber.validateAll('6221260000000000')).toEqual(true);
+      expect(cardNumber.validateAll('6229250000000003')).toEqual(true);
     });
     it('should return false for invalid card numbers', () => {
       // Empty
@@ -132,6 +140,11 @@ describe('card number', () => {
       expect(cardNumber.validateAll('3510000000000000')).toEqual(false);
       expect(cardNumber.validateAll('3060000000000000')).toEqual(false);
       expect(cardNumber.validateAll('5800000000000000')).toEqual(false);
+      // Luhn-valid but below the JCB range, which starts at 3528
+      expect(cardNumber.validateAll('3520000000000005')).toEqual(false);
+      // Luhn-valid but outside the UnionPay/Discover interop range of 622126-622925
+      expect(cardNumber.validateAll('6221250000000001')).toEqual(false);
+      expect(cardNumber.validateAll('6229260000000002')).toEqual(false);
       // Incorrect length for a recognized type
       expect(cardNumber.validateAll('411111111111111')).toEqual(false);
       // Invalid luhn check

--- a/src/credit-card/card-number/utils/card-types.spec.ts
+++ b/src/credit-card/card-number/utils/card-types.spec.ts
@@ -11,6 +11,12 @@ describe('card types', () => {
       expect(cardTypes.validateKnownType('6011111111111117')).toEqual(true);
       expect(cardTypes.validateKnownType('341111111111111')).toEqual(true);
       expect(cardTypes.validateKnownType('36111111111111')).toEqual(true);
+      expect(cardTypes.validateKnownType('3600000000000008')).toEqual(true);
+      expect(cardTypes.validateKnownType('3900000000000005')).toEqual(true);
+      expect(cardTypes.validateKnownType('3095000000000000')).toEqual(true);
+      expect(cardTypes.validateKnownType('3528000000000007')).toEqual(true);
+      expect(cardTypes.validateKnownType('6221260000000000')).toEqual(true);
+      expect(cardTypes.validateKnownType('6229250000000003')).toEqual(true);
 
       // Invalid length for type
       expect(cardTypes.validateKnownType('4')).toEqual(true);
@@ -27,6 +33,13 @@ describe('card types', () => {
       expect(cardTypes.validateKnownType('1111111111111111')).toEqual(false);
       expect(cardTypes.validateKnownType('50')).toEqual(false);
       expect(cardTypes.validateKnownType('57')).toEqual(false);
+      // JCB starts at 3528; 3520-3527 are not issuable
+      expect(cardTypes.validateKnownType('3520000000000005')).toEqual(false);
+      expect(cardTypes.validateKnownType('3527000000000000')).toEqual(false);
+      // UnionPay/Discover interop range starts at 622126
+      expect(cardTypes.validateKnownType('6221250000000000')).toEqual(false);
+      // and ends at 622925
+      expect(cardTypes.validateKnownType('6229260000000000')).toEqual(false);
     });
   });
   describe('validateTypeLength', () => {
@@ -37,6 +50,8 @@ describe('card types', () => {
       expect(cardTypes.validateTypeLength('6011111111111117')).toEqual(true);
       expect(cardTypes.validateTypeLength('341111111111111')).toEqual(true);
       expect(cardTypes.validateTypeLength('36111111111111')).toEqual(true);
+      expect(cardTypes.validateTypeLength('3600000000000008')).toEqual(true);
+      expect(cardTypes.validateTypeLength('3900000000000005')).toEqual(true);
     });
     it('should return false for invalid numbers', () => {
       expect(cardTypes.validateTypeLength('41111111111111')).toEqual(false);
@@ -86,20 +101,34 @@ describe('card types', () => {
       expect(cardTypes.getCardTypeName('647')).toEqual('Discover');
       expect(cardTypes.getCardTypeName('648')).toEqual('Discover');
       expect(cardTypes.getCardTypeName('649')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('622')).toEqual('Discover');
       expect(cardTypes.getCardTypeName('6011')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('352')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('353')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('354')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('355')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('356')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('357')).toEqual('Discover');
-      expect(cardTypes.getCardTypeName('358')).toEqual('Discover');
       expect(cardTypes.getCardTypeName('6500000000000000')).toEqual('Discover');
+      // UnionPay/Discover interop range is 622126-622925
+      expect(cardTypes.getCardTypeName('622126')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622129')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622130')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622199')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622200')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622899')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622900')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622919')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622920')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('622925')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('6221260000000000')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('6229250000000003')).toEqual('Discover');
+      // JCB range is 3528-3589
+      expect(cardTypes.getCardTypeName('3528')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('3529')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('3530')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('3540')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('3589')).toEqual('Discover');
+      expect(cardTypes.getCardTypeName('3528000000000007')).toEqual('Discover');
     });
     it('should detect Diners Club correctly', () => {
       expect(cardTypes.getCardTypeName('36')).toEqual('Diners Club');
       expect(cardTypes.getCardTypeName('38')).toEqual('Diners Club');
+      expect(cardTypes.getCardTypeName('39')).toEqual('Diners Club');
+      expect(cardTypes.getCardTypeName('3095')).toEqual('Diners Club');
       expect(cardTypes.getCardTypeName('300')).toEqual('Diners Club');
       expect(cardTypes.getCardTypeName('301')).toEqual('Diners Club');
       expect(cardTypes.getCardTypeName('302')).toEqual('Diners Club');
@@ -107,11 +136,28 @@ describe('card types', () => {
       expect(cardTypes.getCardTypeName('304')).toEqual('Diners Club');
       expect(cardTypes.getCardTypeName('305')).toEqual('Diners Club');
       expect(cardTypes.getCardTypeName('36000000000000')).toEqual('Diners Club');
+      expect(cardTypes.getCardTypeName('3600000000000008')).toEqual('Diners Club');
+      expect(cardTypes.getCardTypeName('3900000000000005')).toEqual('Diners Club');
+      expect(cardTypes.getCardTypeName('3095000000000000')).toEqual('Diners Club');
     });
     it('should return an empty string for an unknown type', () => {
-      expect(cardTypes.getCardTypeName('39')).toEqual('');
       expect(cardTypes.getCardTypeName('111111111')).toEqual('');
       expect(cardTypes.getCardTypeName('33333')).toEqual('');
+      // 3520-3527 is below the JCB range
+      expect(cardTypes.getCardTypeName('3520')).toEqual('');
+      expect(cardTypes.getCardTypeName('3527')).toEqual('');
+      expect(cardTypes.getCardTypeName('3520000000000005')).toEqual('');
+      // 3590 and up is above the JCB range
+      expect(cardTypes.getCardTypeName('3590')).toEqual('');
+      // outside the UnionPay/Discover interop range of 622126-622925
+      expect(cardTypes.getCardTypeName('622125')).toEqual('');
+      expect(cardTypes.getCardTypeName('622926')).toEqual('');
+      expect(cardTypes.getCardTypeName('6221250000000000')).toEqual('');
+      expect(cardTypes.getCardTypeName('6229260000000000')).toEqual('');
+      // 306-308 and 3090-3094, 3096-3099 are not Diners Club
+      expect(cardTypes.getCardTypeName('306')).toEqual('');
+      expect(cardTypes.getCardTypeName('3094')).toEqual('');
+      expect(cardTypes.getCardTypeName('3096')).toEqual('');
     });
   });
 
@@ -120,10 +166,12 @@ describe('card types', () => {
       expect(cardTypes.expectedLength('4111111111111')).toEqual([13,16]);
       expect(cardTypes.expectedLength('51')).toEqual([16]);
       expect(cardTypes.expectedLength('34')).toEqual([15]);
+      expect(cardTypes.expectedLength('36')).toEqual([14, 16]);
+      expect(cardTypes.expectedLength('39')).toEqual([14, 16]);
     });
     it('should return undefined for an unknown type', () => {
       expect(cardTypes.expectedLength('11')).toEqual(undefined);
-      expect(cardTypes.expectedLength('39')).toEqual(undefined);
+      expect(cardTypes.expectedLength('31')).toEqual(undefined);
     });
   });
 });

--- a/src/credit-card/card-number/utils/card-types.ts
+++ b/src/credit-card/card-number/utils/card-types.ts
@@ -22,13 +22,15 @@ export const cardTypeConsts = [
   {
     name: 'Discover',
     lengths: [16],
-    prefixExpression: '65|64[4-9]|622|6011|35[2-8]',
+    // 622126-622925 is the UnionPay range that interoperates with the Discover network
+    // 3528-3589 is the JCB range, which is processed on the Discover network in the US
+    prefixExpression: '65|64[4-9]|62212[6-9]|6221[3-9][0-9]|622[2-8][0-9][0-9]|6229[01][0-9]|62292[0-5]|6011|35(2[89]|[3-8][0-9])',
     cvvLengths: [3]
   },
   {
     name: 'Diners Club',
-    lengths: [14],
-    prefixExpression: '36|38|30[0-5]',
+    lengths: [14, 16],
+    prefixExpression: '36|3[89]|30[0-5]|3095',
     cvvLengths: [3]
   }
 ];


### PR DESCRIPTION
## Findings

BIN-range drift in `src/credit-card/card-number/utils/card-types.ts` (criticality: low), verified against current (2026) brand rules:

1. **JCB lower boundary (`35[2-8]`)** — JCB issuance starts at **3528**, but the Discover expression claimed 3520–3527 as well. A Luhn-valid number such as `3520000000000005` passes `validateAll` today, then hard-declines at the gateway because no issuer owns that BIN. Tightened to `35(2[89]|[3-8][0-9])` (3528–3589).
2. **Bare `622` prefix** — the UnionPay range that interoperates with the Discover network is only **622126–622925**. The old expression accepted any `622xxxxxxxxxxxxx` (e.g. `6221250000000001`, `6229260000000002` — both Luhn-valid, both outside the interop range). Replaced with `62212[6-9]|6221[3-9][0-9]|622[2-8][0-9][0-9]|6229[01][0-9]|62292[0-5]`.
3. **Diners Club stuck in the 14-digit era** (`{ lengths: [14], prefixExpression: '36|38|30[0-5]' }`) — modern Diners Club is 14–19 digits (16 is common via the Discover network) and also owns the **39** and **3095** prefixes. A real 16-digit Diners card is rejected by `validateTypeLength` today, and 39-prefix cards are reported as unknown type.
4. **Mastercard** expression was audited and is correct (2221–2720 + 51–55) — left untouched.

## Fix

- Discover: `'65|64[4-9]|62212[6-9]|6221[3-9][0-9]|622[2-8][0-9][0-9]|6229[01][0-9]|62292[0-5]|6011|35(2[89]|[3-8][0-9])'`
- Diners Club: `lengths: [14, 16]`, prefix `'36|3[89]|30[0-5]|3095'`
- Spec updates: removed assertions that codified the old ranges (`'352'`/`'622'` 3-digit prefixes → Discover, `'39'` → unknown), added boundary tests for the 3527/3528, 622125/622126, and 622925/622926 splits, and Luhn-valid `validateAll` fixtures for 16-digit Diners, 39-prefix Diners, 3095, JCB, and both UnionPay boundaries.

Note: the library-wide `validateMaxLength` of 16 in `card-number.ts` is a deliberate separate constraint and is intentionally unchanged here. Supporting 17–19 digit Diners/UnionPay PANs would be a possible follow-up that needs its own gateway verification.

## Risk & compatibility

**This PR changes acceptance behavior, in both directions.** Cards that previously failed client-side validation now pass (16-digit Diners Club, 39-prefix and 3095-prefix Diners), and cards that previously passed now fail (3520–3527 "JCB", 622xxx numbers outside 622126–622925). The newly rejected numbers are non-issuable BINs that would have declined at the gateway anyway, but the newly accepted ones will now reach TSYS. **Before merging, someone should confirm the TSYS acquiring setup actually accepts 16-digit Diners Club and the tightened UnionPay range** — otherwise these cards will pass client-side validation and fail at authorization.

One UI-visible subtlety: partial-input brand detection for UnionPay/JCB now requires more typed digits (`getCardTypeName('622')` returned `'Discover'` before; the brand now resolves once 6 digits / 4 digits are entered, respectively), since the prefix regex is anchored and matched against whatever has been typed so far.

## Verification

- `yarn lint` — 0 errors (67 pre-existing style warnings, unchanged)
- `npx karma start --browsers ChromeHeadless --single-run` — **142 passed, 1 failed**, matching the documented baseline exactly; the single failure is the known environment-only TSYS live test ("should successfully receive a token from TSYS" — `Failed to fetch`, requires network access to TSYS)
- New regexes additionally sanity-checked in node against all range boundaries (622125/622126/622925/622926, 3527/3528/3589/3590, 3094/3095/3096, 305/306)

_Automated review PR generated with Claude Code — please review carefully before merging._
